### PR TITLE
fix(portfolio): runtime service updates for issue #20

### DIFF
--- a/packages/backend/src/db/portfolioDb.ts
+++ b/packages/backend/src/db/portfolioDb.ts
@@ -9,6 +9,10 @@ import type { TimeseriesPoint } from '../services/portfolioService';
 let pool: Pool | null = null;
 let schemaInitialized = false;
 
+const SCHEMA_INIT_MAX_RETRIES = 3;
+const SCHEMA_INIT_RETRY_DELAY_MS = 2000;
+const TRANSIENT_SCHEMA_INIT_CODES = new Set(['40P01', '55P03', '40001']);
+
 function getPool(): Pool | null {
   const url = process.env.DATABASE_URL?.trim();
   if (!url) return null;
@@ -109,12 +113,31 @@ on funnel_events (event_ts desc);
 export async function initSchema(): Promise<void> {
   const p = getPool();
   if (!p || schemaInitialized) return;
-  try {
-    await p.query(SCHEMA_SQL);
-    schemaInitialized = true;
-    console.log('[portfolioDb] Schema initialized');
-  } catch (err) {
-    console.error('[portfolioDb] Schema init failed:', err);
+  for (let attempt = 1; attempt <= SCHEMA_INIT_MAX_RETRIES; attempt++) {
+    try {
+      await p.query(SCHEMA_SQL);
+      schemaInitialized = true;
+      console.log('[portfolioDb] Schema initialized');
+      return;
+    } catch (err) {
+      const code =
+        typeof err === 'object' && err !== null && 'code' in err
+          ? String((err as { code?: string }).code ?? '')
+          : '';
+      const shouldRetry =
+        TRANSIENT_SCHEMA_INIT_CODES.has(code) && attempt < SCHEMA_INIT_MAX_RETRIES;
+
+      if (shouldRetry) {
+        console.warn(
+          `[portfolioDb] Schema init transient failure (code=${code}), retry ${attempt}/${SCHEMA_INIT_MAX_RETRIES} in ${SCHEMA_INIT_RETRY_DELAY_MS}ms`
+        );
+        await new Promise((resolve) => setTimeout(resolve, SCHEMA_INIT_RETRY_DELAY_MS));
+        continue;
+      }
+
+      console.error('[portfolioDb] Schema init failed:', err);
+      return;
+    }
   }
 }
 

--- a/packages/backend/src/services/portfolioService.ts
+++ b/packages/backend/src/services/portfolioService.ts
@@ -6,6 +6,7 @@
 import { ethers } from 'ethers';
 import { Connection, PublicKey } from '@solana/web3.js';
 import { getPricesUsd } from './priceService';
+import { resolveRpcUrl } from '../utils/rpc';
 
 // --- Types ---
 export type PortfolioChain = 'evm' | 'solana';
@@ -53,6 +54,7 @@ function toMs(ts: number): number {
 const cache = new Map<string, { data: unknown; expires: number }>();
 const CACHE_TTL_MS = 30_000;
 const CACHE_TTL_NATIVE_MS = 90_000; // Longer for Alchemy-heavy EVM native scan
+const EVM_LOG_CHUNK_BLOCKS = Math.max(1, parseInt(process.env.EVM_LOG_CHUNK_BLOCKS || '900', 10) || 900);
 
 function getCached<T>(key: string): T | null {
   const entry = cache.get(key);
@@ -62,6 +64,26 @@ function getCached<T>(key: string): T | null {
 
 function setCache(key: string, data: unknown, ttlMs: number = CACHE_TTL_MS): void {
   cache.set(key, { data, expires: Date.now() + ttlMs });
+}
+
+async function queryFilterChunked(
+  contract: ethers.Contract,
+  filter: unknown,
+  fromBlock: number,
+  toBlock: number,
+  chunkSize: number = EVM_LOG_CHUNK_BLOCKS
+): Promise<ethers.EventLog[]> {
+  const events: ethers.EventLog[] = [];
+  let start = fromBlock;
+
+  while (start <= toBlock) {
+    const end = Math.min(start + chunkSize - 1, toBlock);
+    const chunk = (await contract.queryFilter(filter as never, start, end)) as ethers.EventLog[];
+    events.push(...chunk);
+    start = end + 1;
+  }
+
+  return events;
 }
 
 // --- EVM ---
@@ -74,16 +96,6 @@ const USDC_BY_CHAIN: Record<number, string> = {
   8453: USDC_BASE,
 };
 
-function resolveEvmRpc(): string {
-  const url = process.env.EVM_RPC_URL?.trim();
-  if (url) return url;
-  const key = process.env.ALCHEMY_API_KEY?.trim();
-  if (key) return `https://eth-mainnet.g.alchemy.com/v2/${key}`;
-  const infura = process.env.INFURA_PROJECT_ID?.trim();
-  if (infura) return `https://mainnet.infura.io/v3/${infura}`;
-  return 'https://eth.llamarpc.com';
-}
-
 export async function getEvmPortfolio(userAddress: string): Promise<PortfolioSummary | null> {
   const arbAddress = process.env.EVM_ARB_ACCOUNT?.trim();
   if (!arbAddress || !/^0x[a-fA-F0-9]{40}$/.test(arbAddress)) return null;
@@ -94,7 +106,17 @@ export async function getEvmPortfolio(userAddress: string): Promise<PortfolioSum
   if (cached) return cached;
 
   try {
-    const provider = new ethers.JsonRpcProvider(resolveEvmRpc());
+    const provider = new ethers.JsonRpcProvider(
+      resolveRpcUrl('evm', [
+        process.env.ALCHEMY_API_KEY?.trim()
+          ? `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY.trim()}`
+          : '',
+        process.env.INFURA_PROJECT_ID?.trim()
+          ? `https://mainnet.infura.io/v3/${process.env.INFURA_PROJECT_ID.trim()}`
+          : '',
+        'https://eth.llamarpc.com',
+      ]) ?? 'https://eth.llamarpc.com'
+    );
     const chainId = (await provider.getNetwork()).chainId;
 
     const deposits: PortfolioSummary['deposits'] = [];
@@ -112,7 +134,7 @@ export async function getEvmPortfolio(userAddress: string): Promise<PortfolioSum
     const usdc = new ethers.Contract(usdcAddress, ethAbi, provider);
     const usdcFilter = usdc.filters?.Transfer?.(userAddress, arbAddress) ?? null;
     const usdcEvents = usdcFilter
-      ? await usdc.queryFilter(usdcFilter, fromBlock, currentBlock)
+      ? await queryFilterChunked(usdc, usdcFilter, fromBlock, currentBlock)
       : [];
 
     for (const ev of usdcEvents) {
@@ -135,7 +157,16 @@ export async function getEvmPortfolio(userAddress: string): Promise<PortfolioSum
     const alchemyKey = process.env.ALCHEMY_API_KEY?.trim();
     if (scanNative && alchemyKey) {
       try {
-        const rpcUrl = resolveEvmRpc();
+        const rpcUrl =
+          resolveRpcUrl('evm', [
+            process.env.ALCHEMY_API_KEY?.trim()
+              ? `https://eth-mainnet.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY.trim()}`
+              : '',
+            process.env.INFURA_PROJECT_ID?.trim()
+              ? `https://mainnet.infura.io/v3/${process.env.INFURA_PROJECT_ID.trim()}`
+              : '',
+            'https://eth.llamarpc.com',
+          ]) ?? 'https://eth.llamarpc.com';
         const nativeLookbackBlocks = Math.min(lookbackBlocks, nativeLookbackDays * BLOCKS_PER_DAY);
         const fromBlockHex = `0x${Math.max(0, currentBlock - nativeLookbackBlocks).toString(16)}`;
         const body = {
@@ -271,15 +302,6 @@ export async function getEvmTimeseries(
 }
 
 // --- Solana ---
-function resolveSolanaRpc(): string {
-  const url = process.env.SOLANA_RPC_URL?.trim();
-  if (url) return url;
-  const cluster = process.env.SOLANA_CLUSTER || 'devnet';
-  if (cluster === 'mainnet-beta') return 'https://api.mainnet-beta.solana.com';
-  if (cluster === 'testnet') return 'https://api.testnet.solana.com';
-  return 'https://api.devnet.solana.com';
-}
-
 const LAMPORTS_PER_SOL = 1e9;
 
 export async function getSolanaPortfolio(userPubkey: string): Promise<PortfolioSummary | null> {
@@ -293,7 +315,15 @@ export async function getSolanaPortfolio(userPubkey: string): Promise<PortfolioS
   if (cached) return cached;
 
   try {
-    const connection = new Connection(resolveSolanaRpc());
+    const cluster = process.env.SOLANA_CLUSTER || 'devnet';
+    const solanaFallback =
+      cluster === 'mainnet-beta'
+        ? 'https://api.mainnet-beta.solana.com'
+        : cluster === 'testnet'
+          ? 'https://api.testnet.solana.com'
+          : 'https://api.devnet.solana.com';
+
+    const connection = new Connection(resolveRpcUrl('solana', [solanaFallback]) ?? solanaFallback);
     const arbPubkey = new PublicKey(arbAddress);
     const userKey = new PublicKey(userPubkey);
 
@@ -391,7 +421,7 @@ export async function getSolanaPortfolio(userPubkey: string): Promise<PortfolioS
       balances: [
         { symbol: 'SOL', amount: arbBalanceSol.toFixed(6), usd: balanceUsd },
       ],
-      deposits: deposits.slice(0, 20).sort((a, b) => b.ts - a.ts),
+      deposits: deposits.sort((a, b) => b.ts - a.ts).slice(0, 20),
       withdrawals: [],
       updatedAt: Date.now(),
     };

--- a/packages/bot/src/services/ArbitrageBot.ts
+++ b/packages/bot/src/services/ArbitrageBot.ts
@@ -141,7 +141,7 @@ export class ArbitrageBot {
 
     // One-time token approvals for Sepolia routers (before scan loop)
     const isSepolia = this.botConfig.network === 'testnet' && this.botConfig.evmChain === 'ethereum';
-    if (isSepolia && this.executionService) {
+    if (isSepolia && this.executionService && !this.botConfig.logOnly) {
       try {
         await this.executionService.ensureSepoliaRouterApprovals();
       } catch (e) {
@@ -149,6 +149,8 @@ export class ArbitrageBot {
           error: e instanceof Error ? e.message : String(e),
         });
       }
+    } else if (isSepolia && this.botConfig.logOnly) {
+      this.logger.info('LOG_ONLY enabled: skipping router approval transactions');
     }
 
     // Start the main loop


### PR DESCRIPTION
## Summary\n- import deferred runtime updates from origin/chore/secret-scan-ci-validation-20260312 for Issue #20 scope\n- update EVM/Solana RPC resolution usage in portfolio service\n- add transient Postgres schema-init retry behavior in portfolio DB\n- add log-only approval guard in bot startup\n- fix Solana deposit ordering bug by sorting before slicing (most recent 20)\n\n## Files\n- packages/backend/src/services/portfolioService.ts\n- packages/backend/src/db/portfolioDb.ts\n- packages/bot/src/services/ArbitrageBot.ts\n\n## Must-fix included\n- changed from deposits.slice(0, 20).sort(...) to deposits.sort(...).slice(0, 20)\n\n## Known limitations (tracked separately)\n- Alchemy native ETH scan returns max 1000 transfers per call; pagination not implemented.\n  Acceptable for MVP wallet sizes. Backlog: add pageKey pagination for high-volume wallets.\n- chainId fallback to USDC_MAINNET when chain is unrecognized logs silently.\n  Low risk for current supported chains (1, 42161, 8453).\n\n## Validation\n- workspace diagnostics: no errors in touched TS files\n