### PR TITLE
ci: add explicit Foundry dependencies for contracts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,10 @@ jobs:
       - name: Install Foundry libs
         working-directory: packages/contracts
         run: |
-          forge install
+          forge install OpenZeppelin/openzeppelin-contracts@v4.9.6
+          forge install foundry-rs/forge-std@v1.5.0
+          forge install Uniswap/v3-core@v1.0.0
+          forge install Uniswap/v3-periphery@v1.3.0
 
       # Note: --if-present must precede the script name to be treated as a pnpm
       # flag, not forwarded as a CLI argument to vitest/jest/forge.


### PR DESCRIPTION
Follow-up to PR #25. Ensures CI installs the same pinned dependency versions that local development uses.

Dependencies:
- OpenZeppelin/openzeppelin-contracts@v4.9.6
- foundry-rs/forge-std@v1.5.0
- Uniswap/v3-core@v1.0.0
- Uniswap/v3-periphery@v1.3.0

This makes contracts CI reproducible across environments.