### PR TITLE
ci(smoke): install pnpm on Windows smoke runners

### DIFF
--- a/.github/workflows/nightly-smoke.yml
+++ b/.github/workflows/nightly-smoke.yml
@@ -15,6 +15,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: Validate required secrets
         shell: pwsh
         env:

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -26,6 +26,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+
       - name: Resolve endpoints
         id: resolve
         shell: pwsh


### PR DESCRIPTION
﻿Fixes smoke workflow failures on Windows runners where pnpm is not on PATH.

## What changed
- Added Node setup in smoke workflows
- Added pnpm setup (v10.27.0) to match repository packageManager
- Applied to both post-deploy smoke and nightly smoke jobs before running scripts/smoke-post-deploy.ps1

## Why
The smoke script invokes pnpm for UI runtime smoke checks. Without pnpm setup on windows-latest, smoke fails with "pnpm is not recognized".

## Expected result
Smoke workflows are deterministic and no longer fail due to missing pnpm on runner.
