### PR TITLE
fix(security): CodeQL high batch A — insecure-randomness, url-sanitization, multi-char-sanitization, format-string

### DIFF
--- a/packages/backend/src/routes/admin.ts
+++ b/packages/backend/src/routes/admin.ts
@@ -659,7 +659,8 @@ router.post('/snapshots/run', async (req: Request, res: Response) => {
             if (ok) success++;
             else failed++;
           } catch (err) {
-            console.warn(`[snapshots] ${chain} ${userAddress}:`, err);
+            const chainId = chain === 'evm' ? 'evm' : 'solana'; // sanitize: prevent log injection from tainted req.query.chain
+            console.warn(`[snapshots] ${chainId} ${userAddress}:`, err);
             failed++;
           }
         }

--- a/packages/backend/src/services/AlertService.ts
+++ b/packages/backend/src/services/AlertService.ts
@@ -292,7 +292,7 @@ export async function dispatchAlert(pred: AlertPrediction, webhooks: AlertWebhoo
         webhooks.reddit.subreddit,
         process.env.ALERT_REDDIT_USER_AGENT || 'ArbiMind/1.0',
         title,
-        message.replace(/<[^>]*>/g, '') // Remove HTML tags for Reddit
+        message.replace(/<[^>]{0,200}>/g, '').replace(/[<>]/g, '') // Strip HTML tags (bounded, two-pass — no ReDoS, no residual angle brackets)
       );
       logger.info('Reddit alert dispatched', { success: results.reddit, pair: pred.pairAddress });
     }

--- a/packages/ui/scripts/live-runtime-smoke.mjs
+++ b/packages/ui/scripts/live-runtime-smoke.mjs
@@ -125,11 +125,14 @@ async function auditPath(browser, path) {
     });
   });
 
+  const baseHostname = (() => { try { return new URL(baseUrl).hostname; } catch { return ''; } })();
   page.on('response', (res) => {
     const status = res.status();
     if (status < 400) return;
     const url = res.url();
-    if (!url.includes(baseUrl) && !url.includes('/api/')) return;
+    let resHost = '';
+    try { resHost = new URL(url).hostname; } catch { /* ignore unparseable URLs */ }
+    if (resHost !== baseHostname && !url.includes('/api/')) return;
     badResponses.push({ url: short(url), status });
   });
 

--- a/packages/ui/src/lib/analytics.ts
+++ b/packages/ui/src/lib/analytics.ts
@@ -28,7 +28,7 @@ export function getPersistentCtaVariant(): CtaVariant {
     return existing;
   }
 
-  const assigned: CtaVariant = Math.random() < 0.5 ? 'A' : 'B';
+  const assigned: CtaVariant = (crypto.getRandomValues(new Uint8Array(1))[0] & 1) === 0 ? 'A' : 'B';
   window.localStorage.setItem(CTA_VARIANT_KEY, assigned);
   return assigned;
 }


### PR DESCRIPTION
## Summary

Resolves 5 of the 6 remaining high-severity CodeQL alerts from issue #32 in a single low-risk, surgical PR.

---

## Changes

### Fix #15 — `js/insecure-randomness` · `packages/ui/src/lib/analytics.ts`

| | Code |
|---|---|
| Before | `Math.random() < 0.5 ? 'A' : 'B'` |
| After | `(crypto.getRandomValues(new Uint8Array(1))[0] & 1) === 0 ? 'A' : 'B'` |

`Math.random()` is not cryptographically unpredictable. Replaced with `crypto.getRandomValues()` which is already used elsewhere in the same file for session IDs. The `canUseBrowserApis()` guard ensures we're always in a browser context here, so `crypto` is unconditionally available.

---

### Fix #10 + #16 — `js/incomplete-multi-character-sanitization` + `js/polynomial-redos` · `packages/backend/src/services/AlertService.ts`

| | Code |
|---|---|
| Before | `.replace(/<[^>]*>/g, '')` |
| After | `.replace(/<[^>]{0,200}>/g, '').replace(/[<>]/g, '')` |

Two problems on the same line, fixed together:
- **#10** (incomplete sanitization): The unbounded `<[^>]*>` can leave residual angle brackets when tags are malformed or nested (e.g., `<a<b>>` → `<a>` on first pass). The trailing `.replace(/[<>]/g, '')` removes any remaining `<`/`>` characters, making the strip complete.
- **#16** (polynomial ReDoS): The unbounded `*` quantifier on `[^>]` permits catastrophic backtracking on adversarial input. The `{0,200}` bounded quantifier eliminates this.

---

### Fix #9 — `js/incomplete-url-substring-sanitization` · `packages/ui/scripts/live-runtime-smoke.mjs`

| | Code |
|---|---|
| Before | `if (!url.includes(baseUrl) && !url.includes('/api/')) return;` |
| After | Parse both URLs; compare `.hostname` fields |

`url.includes(baseUrl)` is an incomplete URL check — a URL like `https://evil.com/?r=https://legit.com` would pass the substring test. The fix parses both URLs with `new URL()` and compares `.hostname` directly. A pre-computed `baseHostname` const avoids redundant parsing on every response event.

---

### Fix #8 — `js/tainted-format-string` · `packages/backend/src/routes/admin.ts`

| | Code |
|---|---|
| Before | `` console.warn(`[snapshots] ${chain} ${userAddress}:`, err) `` |
| After | `const chainId = chain === 'evm' ? 'evm' : 'solana';` then log `chainId` |

`chain` originates in `req.query.chain` (user-controlled). Although it is validated to `'evm' | 'solana'` in the route guard, CodeQL tracks the taint origin. The ternary re-derives `chainId` from a literal expression, cutting the taint flow before it reaches the format string. Zero semantic change.

---

## Alerts closed

| Alert | Rule | File |
|---|---|---|
| #15 | `js/insecure-randomness` | `packages/ui/src/lib/analytics.ts` |
| #10 | `js/incomplete-multi-character-sanitization` | `packages/backend/src/services/AlertService.ts` |
| #16 | `js/polynomial-redos` | `packages/backend/src/services/AlertService.ts` |
| #9  | `js/incomplete-url-substring-sanitization` | `packages/ui/scripts/live-runtime-smoke.mjs` |
| #8  | `js/tainted-format-string` | `packages/backend/src/routes/admin.ts` |

Closes #8, #9, #10, #15, #16 (CodeQL alerts on issue #32)

---

## Risk

**Low.** All changes are confined to the exact alert locations:
- `analytics.ts`: same logical outcome (random 50/50 split), now unpredictable
- `AlertService.ts`: Reddit messages are now fully stripped of HTML (same intent, more complete)
- `live-runtime-smoke.mjs`: test-only script; semantics preserved, filter is now more precise
- `admin.ts`: log output is unchanged; only the data source for `chain` changes from tainted to literal