### PR TITLE
fix(security): CodeQL high #11 — unvalidated-dynamic-method-call in engine.ts (closes #32)

### DIFF
--- a/packages/backend/src/routes/engine.ts
+++ b/packages/backend/src/routes/engine.ts
@@ -20,6 +20,9 @@ const strategyRunners: Record<string, (opts?: { referrer?: string }) => Promise<
   'market-making': strategies.runMarketMaking,
 };
 
+// Allowlist derived from the runners map — validates user input before dynamic dispatch
+const VALID_STRATEGIES = new Set<string>(Object.keys(strategyRunners));
+
 function runLoop(): void {
   if (adminStore.isEnginePaused()) return;
   const run = strategyRunners[activeStrategy as keyof typeof strategyRunners];
@@ -70,6 +73,9 @@ function runLoop(): void {
 router.post('/start', (req: Request, res: Response) => {
   try {
     const { strategy = 'arbitrage', referrer, walletAddress, walletChain } = req.body || {};
+    if (!VALID_STRATEGIES.has(strategy)) {
+      return res.status(400).json({ status: 'error', message: `Invalid strategy. Must be one of: ${[...VALID_STRATEGIES].join(', ')}` });
+    }
     activeStrategy = strategy;
     currentReferrer = typeof referrer === 'string' && /^0x[a-fA-F0-9]{40}$/.test(referrer) ? referrer : null;
     const normalizedChain = walletChain === 'solana' || walletChain === 'evm' ? walletChain : null;
@@ -188,6 +194,9 @@ router.get('/logs', (req: Request, res: Response) => {
 router.post('/single-scan', async (req: Request, res: Response) => {
   try {
     const { strategy = activeStrategy || 'arbitrage' } = req.body || {};
+    if (!VALID_STRATEGIES.has(strategy)) {
+      return res.status(400).json({ status: 'error', message: `Invalid strategy. Must be one of: ${[...VALID_STRATEGIES].join(', ')}` });
+    }
     emitEngineEvent({
       level: 'info',
       type: 'engine.scan.requested',


### PR DESCRIPTION
## Summary

Fixes the final high-severity CodeQL alert from issue #32, closing that umbrella tracking issue entirely.

---

## Problem — `js/unvalidated-dynamic-method-call` at engine.ts:35

The engine has a `strategyRunners` map keyed by strategy name and dispatches by calling the looked-up function (`run(opts)`). Two routes accepted the `strategy` value **directly from `req.body`** without validating it against the known set before using it as a dynamic property key:

**`/start`** — user-controlled `strategy` flows into `activeStrategy`, which then reaches `strategyRunners[activeStrategy]` → `run(opts)` inside `runLoop()`:
```ts
const { strategy = 'arbitrage', ... } = req.body || {};
activeStrategy = strategy;  // ← no validation; tainted value persists in module scope
// later in runLoop():
const run = strategyRunners[activeStrategy];
if (!run) return;
run(opts);  // ← CodeQL line 35: dynamic call with tainted receiver
```

**`/single-scan`** — same pattern inline:
```ts
const { strategy = activeStrategy || 'arbitrage' } = req.body || {};
const run = strategyRunners[strategy];  // ← tainted dynamic lookup
if (run) { const summary = await run(opts); }
```

The `if (!run) return` guard prevents unknown keys from being called at runtime, but it doesn't cut the taint flow in CodeQL's dataflow model — the tainted `strategy` string still reaches the call expression.

---

## Fix

Added a `VALID_STRATEGIES` `Set<string>` derived directly from the runners map (so it stays in sync automatically if runners are added), and validated at both entry points **before** any assignment or lookup:

```ts
// Allowlist derived from the runners map — validates user input before dynamic dispatch
const VALID_STRATEGIES = new Set<string>(Object.keys(strategyRunners));
```

Both `/start` and `/single-scan` now reject unknown strategies with HTTP 400 before the tainted value can reach the dispatch:

```ts
if (!VALID_STRATEGIES.has(strategy)) {
  return res.status(400).json({
    status: 'error',
    message: `Invalid strategy. Must be one of: ${[...VALID_STRATEGIES].join(', ')}`
  });
}
```

The existing `if (!run) return` check is preserved as defence-in-depth.

---

## Diff summary

| File | Change |
|---|---|
| `packages/backend/src/routes/engine.ts` | +9 lines: `VALID_STRATEGIES` const + 400-guard in `/start` + 400-guard in `/single-scan` |

---

## Behaviour change

| Scenario | Before | After |
|---|---|---|
| `POST /engine/start { strategy: 'arbitrage' }` | Works | Works (unchanged) |
| `POST /engine/start { strategy: 'INJECTED\nfoo: bar' }` | Silent no-op (runLoop fires, `!run` guard exits) | HTTP 400 with clear error message |
| `POST /engine/single-scan { strategy: 'unknown' }` | Silent no-op | HTTP 400 |

---

## Closes

- CodeQL alert **#11** (`js/unvalidated-dynamic-method-call` — engine.ts:35)
- Closes umbrella issue **#32** (all 6 high alerts now resolved: #8 #9 #10 #11 #15 #16)

## Depends on

PR #34 (`fix/codeql-high-batch-a`) for prior batch — can be merged independently since this touches a different file.