### PR TITLE
ci(security): include UI path in CodeQL Analysis triggers

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,12 +6,14 @@ on:
     paths:
       - 'packages/backend/**'
       - 'packages/bot/**'
+      - 'packages/ui/**'
       - '.github/workflows/codeql-analysis.yml'
   pull_request:
     branches: [main]
     paths:
       - 'packages/backend/**'
       - 'packages/bot/**'
+      - 'packages/ui/**'
       - '.github/workflows/codeql-analysis.yml'
   schedule:
     - cron: '17 3 * * 1'


### PR DESCRIPTION
## Summary

Adds packages/ui/** to .github/workflows/codeql-analysis.yml path filters for both push and pull_request on main.

## Why

A residual high alert (#15) remained open after merge because CodeQL Analysis did not run on the UI-only fix commit (workflow was scoped to backend/bot paths). This caused stale alert indexing for UI code.

## Change

- on.push.paths: add packages/ui/**
- on.pull_request.paths: add packages/ui/**

## Effect

UI security fixes now trigger CodeQL Analysis immediately on PR and on main, preventing stale open alerts in code scanning.
