### PR TITLE
fix(security): resolve remaining CodeQL medium alerts in GitHub workflows

### DIFF
--- a/.github/workflows/bot-build-check.yml
+++ b/.github/workflows/bot-build-check.yml
@@ -11,6 +11,9 @@ on:
       - 'packages/bot/**'
       - '.github/workflows/bot-build-check.yml'
 
+permissions:
+  contents: read
+
 jobs:
   bot-build-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/bot-tests.yml
+++ b/.github/workflows/bot-tests.yml
@@ -9,6 +9,9 @@ on:
     paths:
       - 'packages/bot/**'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 name: CI
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -2,6 +2,10 @@ name: Deploy UI to Vercel
 on:
   push:
     branches: [main]
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-vps.yml
+++ b/.github/workflows/deploy-vps.yml
@@ -2,6 +2,9 @@ name: Deploy to VPS
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: "false"
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
## Summary

Resolves all remaining open medium CodeQL alerts, all from the same rule:

- actions/missing-workflow-permissions (6 alerts)

## What changed

Added explicit top-level least-privilege token permissions to these workflows:

- .github/workflows/ci.yml
- .github/workflows/bot-tests.yml
- .github/workflows/bot-build-check.yml
- .github/workflows/deploy-ui.yml
- .github/workflows/deploy-vps.yml
- .github/workflows/post-deploy-smoke.yml

Pattern applied in each file:

`yaml
permissions:
  contents: read
`

## Why

Without an explicit permissions block, workflows inherit broader default token permissions. These workflows only need repository read access (checkout/build/test/deploy via external systems), so limiting to contents: read follows least-privilege and satisfies CodeQL.

## Alerts addressed

- #5  actions/missing-workflow-permissions
- #7  actions/missing-workflow-permissions
- #18 actions/missing-workflow-permissions
- #19 actions/missing-workflow-permissions
- #20 actions/missing-workflow-permissions
- #21 actions/missing-workflow-permissions

After merge and CodeQL ingestion on main, expected open alert list: []