### PR TITLE
build(bot): fix Vitest/Vite compatibility for bot CI (Issue #60)

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
       "@isaacs/brace-expansion": "5.0.1",
       "diff": ">=4.0.4",
       "ox": "^0.12.0",
+      "vite": "5.4.21",
+      "vitest": "1.6.1",
+      "@vitest/coverage-v8": "1.6.1",
       "typescript": "5.3.3",
       "pino-pretty": "^11.0.0"
     }

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -50,14 +50,15 @@
     "@types/ws": "^8.5.10",
     "@typescript-eslint/eslint-plugin": "^6.13.1",
     "@typescript-eslint/parser": "^6.13.1",
-    "@vitest/coverage-v8": "^1.6.0",
+    "@vitest/coverage-v8": "1.6.1",
     "eslint": "^8.54.0",
     "happy-dom": "^20.8.4",
     "jsdom": "^24.1.1",
     "msw": "^2.0.20",
     "tsx": "^4.6.2",
     "typescript": "^5.3.3",
-    "vitest": "^1.6.0"
+    "vite": "5.4.21",
+    "vitest": "1.6.1"
   },
   "keywords": [
     "arbitrage",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ overrides:
   '@isaacs/brace-expansion': 5.0.1
   diff: '>=4.0.4'
   ox: ^0.12.0
+  vite: 5.4.21
+  vitest: 1.6.1
+  '@vitest/coverage-v8': 1.6.1
   typescript: 5.3.3
   pino-pretty: ^11.0.0
 
@@ -236,7 +239,7 @@ importers:
         specifier: ^6.13.1
         version: 6.21.0(eslint@8.57.1)(typescript@5.3.3)
       '@vitest/coverage-v8':
-        specifier: ^1.6.0
+        specifier: 1.6.1
         version: 1.6.1(vitest@1.6.1(@types/node@20.19.27)(happy-dom@20.8.4(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@24.1.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.1))
       eslint:
         specifier: ^8.54.0
@@ -256,8 +259,11 @@ importers:
       typescript:
         specifier: 5.3.3
         version: 5.3.3
+      vite:
+        specifier: 5.4.21
+        version: 5.4.21(@types/node@20.19.27)(terser@5.46.1)
       vitest:
-        specifier: ^1.6.0
+        specifier: 1.6.1
         version: 1.6.1(@types/node@20.19.27)(happy-dom@20.8.4(bufferutil@4.1.0)(utf-8-validate@5.0.10))(jsdom@24.1.3(bufferutil@4.1.0)(utf-8-validate@5.0.10))(terser@5.46.1)
 
   packages/contracts: {}
@@ -9412,8 +9418,8 @@ snapshots:
 
   '@babel/generator@7.28.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
@@ -9447,7 +9453,7 @@ snapshots:
   '@babel/helper-module-imports@7.27.1':
     dependencies:
       '@babel/traverse': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9487,7 +9493,7 @@ snapshots:
   '@babel/helpers@7.28.4':
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/helpers@7.29.2':
     dependencies:
@@ -9496,7 +9502,7 @@ snapshots:
 
   '@babel/parser@7.28.5':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
@@ -9669,8 +9675,8 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@babel/template@7.28.6':
     dependencies:
@@ -9683,9 +9689,9 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.5
       '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
@@ -13929,24 +13935,24 @@ snapshots:
 
   '@types/babel__core@7.20.5':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       '@types/babel__generator': 7.27.0
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.28.0
 
   '@types/babel__generator@7.27.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/babel__template@7.4.4':
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
 
   '@types/babel__traverse@7.28.0':
     dependencies:
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
 
   '@types/bcryptjs@2.4.6': {}
 
@@ -15803,7 +15809,7 @@ snapshots:
   babel-plugin-jest-hoist@29.6.3:
     dependencies:
       '@babel/template': 7.27.2
-      '@babel/types': 7.28.5
+      '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.28.0
 
@@ -17964,7 +17970,7 @@ snapshots:
   istanbul-lib-instrument@5.2.1:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 6.3.1
@@ -17974,7 +17980,7 @@ snapshots:
   istanbul-lib-instrument@6.0.3:
     dependencies:
       '@babel/core': 7.28.5
-      '@babel/parser': 7.28.5
+      '@babel/parser': 7.29.2
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.2
       semver: 7.7.4
@@ -18623,8 +18629,8 @@ snapshots:
 
   magicast@0.3.5:
     dependencies:
-      '@babel/parser': 7.28.5
-      '@babel/types': 7.28.5
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
       source-map-js: 1.2.1
 
   make-dir@3.1.0:


### PR DESCRIPTION
## Summary\n- isolate Vitest/Vite toolchain fix into a dedicated PR\n- pin a known-compatible pair for bot test runtime:\n  - itest: 1.6.1\n  - ite: 5.4.21\n  - @vitest/coverage-v8: 1.6.1\n- add root pnpm.overrides for the same versions to prevent transitive drift\n\n## Why\nIssue #60 tracks CI failure from a dev-dependency bundle with:\nERR_PACKAGE_PATH_NOT_EXPORTED: Package subpath './module-runner' is not defined by exports in vite/package.json\n\n## Validation\n- ✅ pnpm -C packages/bot exec vitest run tests/unit/identity.test.ts\n- ✅ pnpm --dir packages/bot build\n- ✅ pnpm --dir packages/ui build\n- ⚠️ pnpm --dir packages/backend build fails in this environment with existing TS2742 router typing issues unrelated to this PR scope (no backend package changes in this diff).\n\n## Scope control\n- only 3 files changed:\n  - packages/bot/package.json\n  - package.json\n  - pnpm-lock.yaml\n\nCloses #60