### PR TITLE
chore(security): pin tar to 7.5.11 (follow-up to #64)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "license": "MIT",
   "pnpm": {
     "overrides": {
-      "tar": ">=7.5.7",
+      "tar": "7.5.11",
       "glob": ">=10.5.0",
       "test-exclude@6.0.0>glob": "7.2.3",
       "preact": ">=10.28.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  tar: '>=7.5.7'
+  tar: 7.5.11
   glob: '>=10.5.0'
   test-exclude@6.0.0>glob: 7.2.3
   preact: '>=10.28.2'
@@ -8449,10 +8449,9 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+  tar@7.5.11:
+    resolution: {integrity: sha512-ChjMH33/KetonMTAtpYdgUFr0tbz69Fp2v7zWxQfYZX4g5ZN2nOBXm1R2xyA+lMIKrLKIoKAwFj93jE/avX9cQ==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   technicalindicators@3.1.0:
     resolution: {integrity: sha512-f16mOc+Y05hNy/of+UbGxhxQQmxUztCiluhsqC5QLUYz4WowUgKde9m6nIjK1Kay0wGHigT0IkOabpp0+22UfA==}
@@ -10261,7 +10260,7 @@ snapshots:
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   '@isaacs/ttlcache@1.4.1': {}
 
@@ -10557,7 +10556,7 @@ snapshots:
       npmlog: 5.0.1
       rimraf: 3.0.2
       semver: 7.7.3
-      tar: 7.5.7
+      tar: 7.5.11
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -13548,7 +13547,7 @@ snapshots:
       https-proxy-agent: 2.2.4
       progress: 2.0.3
       rimraf: 2.7.1
-      tar: 7.5.7
+      tar: 7.5.11
     transitivePeerDependencies:
       - encoding
       - seedrandom
@@ -18914,7 +18913,7 @@ snapshots:
 
   minizlib@3.1.0:
     dependencies:
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   mipd@0.0.7(typescript@5.3.3):
     optionalDependencies:
@@ -19487,7 +19486,7 @@ snapshots:
   path-scurry@2.0.1:
     dependencies:
       lru-cache: 11.2.5
-      minipass: 7.1.2
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -20752,11 +20751,11 @@ snapshots:
       - tsx
       - yaml
 
-  tar@7.5.7:
+  tar@7.5.11:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
-      minipass: 7.1.2
+      minipass: 7.1.3
       minizlib: 3.1.0
       yallist: 5.0.0
 


### PR DESCRIPTION
## Summary
- pin 	ar override from >=7.5.7 to exact 7.5.11
- regenerate pnpm-lock.yaml to force patched transitive resolution
- scope intentionally limited to package.json and pnpm-lock.yaml

## Why
Local audit after #64 still reported tar advisories in the @tensorflow/tfjs-node path:
- GHSA-jx8r-chfx-gm7q (1114200) patched in >=7.5.10
- GHSA-56x4-j7p9-fcf9 (1114302) patched in >=7.5.11

This PR aligns to the stricter patched range (7.5.11).

## Validation
- pnpm --filter @arbimind/bot test -- --run ✅
- pnpm --filter @arbimind/bot build ✅
- pnpm --filter @arbimind/ui build ✅
- pnpm audit --json tar extraction => NO_TAR_ACTIONS ✅
