### PR TITLE
chore(ui): clean up remaining lint warnings

### DIFF
--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -1,7 +1,7 @@
 import nextVitals from 'eslint-config-next/core-web-vitals';
 import nextTs from 'eslint-config-next/typescript';
 
-export default [
+const config = [
   ...nextVitals,
   ...nextTs,
   {
@@ -16,3 +16,5 @@ export default [
     }
   }
 ];
+
+export default config;

--- a/packages/ui/scripts/live-runtime-smoke.mjs
+++ b/packages/ui/scripts/live-runtime-smoke.mjs
@@ -18,11 +18,6 @@ const fatalConsolePatterns = [
   /Text content does not match server-rendered HTML/i,
 ];
 
-const softConsolePatterns = [
-  /ChunkLoadError/i,
-  /Loading chunk .* failed/i,
-];
-
 function short(text, max = 220) {
   if (!text) return '';
   return text.length > max ? `${text.slice(0, max)}…` : text;
@@ -30,10 +25,6 @@ function short(text, max = 220) {
 
 function isBenignAbort(url, reason) {
   return reason.includes('ERR_ABORTED') && url.includes('_rsc=');
-}
-
-function isSoftConsoleError(message) {
-  return softConsolePatterns.some((pattern) => pattern.test(message));
 }
 
 function isHardConsoleError(message) {

--- a/packages/ui/src/components/OpportunityFeed.tsx
+++ b/packages/ui/src/components/OpportunityFeed.tsx
@@ -57,7 +57,7 @@ export function OpportunityFeed({ opportunities, onExecute }: OpportunityFeedPro
       } else {
         toast.error(result.error ?? 'Execution failed');
       }
-    } catch (error) {
+    } catch {
       toast.error('Execution failed');
     } finally {
       setExecutingId(null);

--- a/packages/ui/src/hooks/useArbiApi.ts
+++ b/packages/ui/src/hooks/useArbiApi.ts
@@ -211,7 +211,7 @@ async function fetchWithFallback<T>(
       return { data: mockData, shouldRetry: false };
     }
     return { data: mockData, shouldRetry: true };
-  } catch (error) {
+  } catch {
     // Network errors - use mock data, but don't spam retries
     return { data: mockData, shouldRetry: false };
   }

--- a/packages/ui/src/hooks/useBalanceGuard.ts
+++ b/packages/ui/src/hooks/useBalanceGuard.ts
@@ -81,7 +81,7 @@ export function useBalanceGuard() {
     // Defer past hydration + modal close so we don't trigger "setState during render" in RainbowKit
     const t = setTimeout(() => checkBalance(), 2000);
     return () => clearTimeout(t);
-  }, [isConnected, checkBalance]);
+  }, [isConnected, address, checkBalance]);
 
   return { checkBalance, ethBalance, usdcBalance, minEth: MIN_ETH, minUsdc: MIN_USDC };
 }


### PR DESCRIPTION
﻿## Summary
- fix the ESLint config export style warning
- remove the unused helper in the live runtime smoke script
- neutralize unused catch variables in `OpportunityFeed` and `useArbiApi`
- update `useBalanceGuard` to include `address` in the effect dependency array

## Scope
This PR is intentionally limited to warnings-only UI cleanup after the Next 16 / React 19 baseline migration.

Depends on baseline migration PR: [chore(ui): Next 16.2 + React 19 baseline migration](https://github.com/rigocrypto/arbimind/pull/71)

## Validation
- `pnpm --dir packages/ui run lint`
- `pnpm --dir packages/ui run build`

Results:
- lint passes with `0` warnings / `0` errors
- build passes on `Next.js 16.2.0`
