### PR TITLE
fix(deps): pin lodash to 4.17.23 via pnpm overrides (CVE remediation)

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
       "minimatch@<3.1.4": "3.1.4",
       "@typescript-eslint/typescript-estree>minimatch": "9.0.7",
       "eslint>ajv": "6.14.0",
+      "lodash": "4.17.23",
       "typescript": "5.3.3",
       "pino-pretty": "^11.0.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,6 +25,7 @@ overrides:
   minimatch@<3.1.4: 3.1.4
   '@typescript-eslint/typescript-estree>minimatch': 9.0.7
   eslint>ajv: 6.14.0
+  lodash: 4.17.23
   typescript: 5.3.3
   pino-pretty: ^11.0.0
 
@@ -196,7 +197,7 @@ importers:
         specifier: ^6.8.1
         version: 6.16.0(bufferutil@4.1.0)(utf-8-validate@5.0.10)
       lodash:
-        specifier: ^4.17.23
+        specifier: 4.17.23
         version: 4.17.23
       ml-matrix:
         specifier: ^6.10.4
@@ -6704,9 +6705,6 @@ packages:
 
   lodash.throttle@4.1.1:
     resolution: {integrity: sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==}
-
-  lodash@4.17.21:
-    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
 
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
@@ -15316,7 +15314,7 @@ snapshots:
       '@walletconnect/types': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.2)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)))
       '@walletconnect/utils': 2.19.0(@react-native-async-storage/async-storage@1.24.0(react-native@0.83.1(@babel/core@7.29.0)(@types/react@19.2.2)(bufferutil@4.1.0)(react@19.2.0)(utf-8-validate@5.0.10)))(bufferutil@4.1.0)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.25.76)
       events: 3.3.0
-      lodash: 4.17.21
+      lodash: 4.17.23
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -18804,8 +18802,6 @@ snapshots:
   lodash.once@4.1.1: {}
 
   lodash.throttle@4.1.1: {}
-
-  lodash@4.17.21: {}
 
   lodash@4.17.23: {}
 


### PR DESCRIPTION
## Summary
- Pin transitive lodash to 4.17.23 via root pnpm.overrides.
- Update lockfile resolution to enforce the patched version.

## Vulnerable Path (Dependabot #39)
- Vulnerable lodash was pulled transitively through the WalletConnect/Solana wallet adapter chain in packages/ui dependencies.
- Alert metadata indicates first patched version is 4.17.23.

## What Changed
- package.json: add root override for lodash: 4.17.23.
- pnpm-lock.yaml: re-resolve graph so active lodash resolution is 4.17.23.

## Validation
- Clean worktree used to ensure strict scope.
- Built UI successfully in clean branch:
  - pnpm --dir packages/ui run build ✅

## Dependabot Behavior
- Expect Dependabot alert #39 to auto-close after merge and next default-branch rescan.
- Not manually closing #39 in this PR.

## Deferred / Tracked Separately
- Dependabot #56 (elliptic) investigated.
- No patched upstream version currently available in the resolved transitive chain; remediation is upstream-blocked for now and tracked separately.