### PR TITLE
chore(ui): post-migration lint hardening (issue #76)

### DIFF
--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -12,6 +12,12 @@ const config = [
       'react-hooks/preserve-manual-memoization': 'off',
       'react-hooks/incompatible-library': 'off',
       'react-hooks/purity': 'off',
+      '@typescript-eslint/no-require-imports': 'error'
+    }
+  },
+  {
+    files: ['next.config.js'],
+    rules: {
       '@typescript-eslint/no-require-imports': 'off'
     }
   }


### PR DESCRIPTION
## Summary
Post-migration lint hardening pass for packages/ui after Next 16.2 + React 19 baseline landing.

## What Was Tightened
- Promoted @typescript-eslint/no-require-imports from off to error in packages/ui/eslint.config.mjs.

## Intentional Exception (Scoped)
- Added an explicit exception for 
ext.config.js:
  - @typescript-eslint/no-require-imports: off
- Rationale: Next config currently uses CommonJS (equire/module.exports) and this PR is intentionally scoped to lint-policy hardening without config-format migration.

## Current Policy Snapshot
- Still disabled (migration-temporary/deferred):
  - eact-hooks/static-components
  - eact-hooks/set-state-in-effect
  - eact-hooks/preserve-manual-memoization
  - eact-hooks/incompatible-library
  - eact-hooks/purity
- Warnings explicitly configured in this file: none

## Validation
- pnpm --dir packages/ui run lint ✅ (0 errors)
- pnpm --dir packages/ui run build ✅

## Deferred From This Pass
- Re-enabling the remaining eact-hooks/* rules is tracked in #83 to keep this PR small and reviewable.

Closes #76