### PR TITLE
fix(ui): promote react-hooks/static-components to error (issue #83)

### DIFF
--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -7,7 +7,7 @@ const config = [
   {
     ignores: ['.next/**', 'node_modules/**', 'out/**', 'dist/**'],
     rules: {
-      'react-hooks/static-components': 'off',
+      'react-hooks/static-components': 'error',
       'react-hooks/set-state-in-effect': 'off',
       'react-hooks/preserve-manual-memoization': 'off',
       'react-hooks/incompatible-library': 'off',

--- a/packages/ui/src/components/Charts/PNLChart.tsx
+++ b/packages/ui/src/components/Charts/PNLChart.tsx
@@ -30,6 +30,21 @@ const formatTime = (ts: number) => {
   return d.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false });
 };
 
+function PNLChartTooltip({ active, payload, label }: { active?: boolean; payload?: { value: number; payload: { profitPct: number } }[]; label?: string }) {
+  if (!active || !payload?.length || !label) return null;
+  const profit = payload[0]?.value ?? 0;
+  const pct = payload[0]?.payload?.profitPct ?? 0;
+  return (
+    <div className="rounded-lg border border-dark-600 bg-dark-800/95 px-3 py-2 shadow-xl backdrop-blur">
+      <div className="text-xs text-dark-400">{label}</div>
+      <div className="text-sm font-bold text-white">{formatETH(profit)} ETH</div>
+      <div className={`text-xs font-medium ${pct >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+        {formatPercent(pct)}
+      </div>
+    </div>
+  );
+}
+
 interface PNLChartProps {
   data: number[];
   timestamps: number[];
@@ -55,21 +70,6 @@ export function PNLChart({ data, timestamps }: PNLChartProps) {
   const lastProfit = chartData[chartData.length - 1]?.profit ?? 0;
   const firstProfit = chartData[0]?.profit ?? 0;
   const profitPct = firstProfit !== 0 ? ((lastProfit - firstProfit) / Math.abs(firstProfit)) * 100 : 0;
-
-  const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: { value: number; payload: { profitPct: number } }[]; label?: string }) => {
-    if (!active || !payload?.length || !label) return null;
-    const profit = payload[0]?.value ?? 0;
-    const pct = payload[0]?.payload?.profitPct ?? 0;
-    return (
-      <div className="rounded-lg border border-dark-600 bg-dark-800/95 px-3 py-2 shadow-xl backdrop-blur">
-        <div className="text-xs text-dark-400">{label}</div>
-        <div className="text-sm font-bold text-white">{formatETH(profit)} ETH</div>
-        <div className={`text-xs font-medium ${pct >= 0 ? 'text-green-400' : 'text-red-400'}`}>
-          {formatPercent(pct)}
-        </div>
-      </div>
-    );
-  };
 
   return (
     <div className="relative w-full h-full min-h-[140px]">
@@ -108,7 +108,7 @@ export function PNLChart({ data, timestamps }: PNLChartProps) {
             domain={['auto', 'auto']}
           />
 
-          <Tooltip content={<CustomTooltip />} cursor={{ stroke: '#00ff88', strokeWidth: 1, strokeDasharray: '4 4' }} />
+          <Tooltip content={<PNLChartTooltip />} cursor={{ stroke: '#00ff88', strokeWidth: 1, strokeDasharray: '4 4' }} />
 
           <Area
             type="monotone"

--- a/packages/ui/src/components/admin/AdminCharts.tsx
+++ b/packages/ui/src/components/admin/AdminCharts.tsx
@@ -20,6 +20,16 @@ import { format } from 'date-fns';
 
 const COLORS = ['#22c55e', '#06b6d4', '#8b5cf6'];
 
+function AdminChartTooltip({ active, payload, label }: { active?: boolean; payload?: { value: number }[]; label?: string }) {
+  if (!active || !payload?.length || !label) return null;
+  return (
+    <div className="rounded-lg border border-dark-600 bg-dark-800/95 px-3 py-2 shadow-xl">
+      <div className="text-xs text-dark-400">{label}</div>
+      <div className="text-sm font-bold text-white">{payload[0]?.value?.toFixed(4) ?? 0} ETH</div>
+    </div>
+  );
+}
+
 interface AdminChartsProps {
   pnlSeries: { time: number; netProfit: number; gasCost: number }[];
   txsByStrategy: { strategy: string; profit: number }[];
@@ -45,16 +55,6 @@ export function AdminCharts({ pnlSeries, txsByStrategy, range }: AdminChartsProp
       .slice(-20);
   }, [pnlSeries, range]);
 
-  const CustomTooltip = ({ active, payload, label }: { active?: boolean; payload?: { value: number }[]; label?: string }) => {
-    if (!active || !payload?.length || !label) return null;
-    return (
-      <div className="rounded-lg border border-dark-600 bg-dark-800/95 px-3 py-2 shadow-xl">
-        <div className="text-xs text-dark-400">{label}</div>
-        <div className="text-sm font-bold text-white">{payload[0]?.value?.toFixed(4) ?? 0} ETH</div>
-      </div>
-    );
-  };
-
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
       <div className="card">
@@ -71,7 +71,7 @@ export function AdminCharts({ pnlSeries, txsByStrategy, range }: AdminChartsProp
               <CartesianGrid strokeDasharray="3 3" stroke="#334155" opacity={0.5} />
               <XAxis dataKey="timeStr" tick={{ fill: '#94a3b8', fontSize: 11 }} />
               <YAxis tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(v) => v.toFixed(3)} />
-              <Tooltip content={<CustomTooltip />} />
+              <Tooltip content={<AdminChartTooltip />} />
               <Area type="monotone" dataKey="netProfit" stroke="#22c55e" fill="url(#adminPnlGrad)" strokeWidth={2} />
             </AreaChart>
           </ResponsiveContainer>
@@ -85,7 +85,7 @@ export function AdminCharts({ pnlSeries, txsByStrategy, range }: AdminChartsProp
               <CartesianGrid strokeDasharray="3 3" stroke="#334155" opacity={0.5} />
               <XAxis dataKey="time" tick={{ fill: '#94a3b8', fontSize: 11 }} />
               <YAxis tick={{ fill: '#94a3b8', fontSize: 11 }} tickFormatter={(v) => v.toFixed(4)} />
-              <Tooltip content={<CustomTooltip />} />
+              <Tooltip content={<AdminChartTooltip />} />
               <Bar dataKey="gas" fill="#f97316" radius={[4, 4, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>

--- a/packages/ui/src/components/portfolio/PerformanceCharts.tsx
+++ b/packages/ui/src/components/portfolio/PerformanceCharts.tsx
@@ -29,6 +29,18 @@ const formatTs = (ts: number) => {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
 };
 
+function EquityTooltip({ active, payload, label, isEstimated }: { active?: boolean; payload?: { value?: unknown }[]; label?: string; isEstimated?: boolean }) {
+  if (!active || !payload?.length || !label) return null;
+  const v = Number(payload[0]?.value ?? 0);
+  return (
+    <div className="rounded-lg border border-dark-600 bg-dark-800/95 px-3 py-2 shadow-xl backdrop-blur">
+      <div className="text-xs text-dark-400">{label}</div>
+      <div className="text-sm font-bold text-white">{formatUSD(v)}</div>
+      {isEstimated && <div className="text-[10px] text-dark-500 mt-1">Estimated history — final point is live equity</div>}
+    </div>
+  );
+}
+
 export function PerformanceCharts({ points, method, isLoading }: PerformanceChartsProps) {
   const isEstimated = method === 'estimated_linear_ramp_to_current_equity';
   const chartData = useMemo(() => {
@@ -37,18 +49,6 @@ export function PerformanceCharts({ points, method, isLoading }: PerformanceChar
       label: formatTs(p.ts),
     }));
   }, [points]);
-
-  const EquityTooltip = ({ active, payload, label }: { active?: boolean; payload?: { value?: unknown }[]; label?: string }) => {
-    if (!active || !payload?.length || !label) return null;
-    const v = Number(payload[0]?.value ?? 0);
-    return (
-      <div className="rounded-lg border border-dark-600 bg-dark-800/95 px-3 py-2 shadow-xl backdrop-blur">
-        <div className="text-xs text-dark-400">{label}</div>
-        <div className="text-sm font-bold text-white">{formatUSD(v)}</div>
-        {isEstimated && <div className="text-[10px] text-dark-500 mt-1">Estimated history — final point is live equity</div>}
-      </div>
-    );
-  };
 
   if (isLoading) {
     return (
@@ -98,7 +98,7 @@ export function PerformanceCharts({ points, method, isLoading }: PerformanceChar
                 tickLine={{ stroke: '#374151' }}
                 tickFormatter={(v) => formatUSD(v)}
               />
-              <Tooltip content={<EquityTooltip />} />
+              <Tooltip content={<EquityTooltip isEstimated={isEstimated} />} />
               <Line
                 type="monotone"
                 dataKey="equityUsd"


### PR DESCRIPTION
## Summary

Continues the incremental lint hardening started in #82 (ref: issue #76). Promotes one React Compiler lint rule from `off` to `error`, fixes all resulting violations, and documents the remaining deferred rules with rationale.

Closes #83

---

## Rule Disposition

| Rule | Decision | Rationale |
|---|---|---|
| `react-hooks/static-components` | ✅ Promoted to `error` | 4 violations fixed by extracting inline tooltip components to module scope |
| `react-hooks/purity` | ⏸️ Kept `off` | 9 `Date.now()` calls in mock/status display code across `AnalystCharts.tsx` and `SystemStatus.tsx`; fixing requires `useMemo`/`useState` refactor — out of scope for incremental hardening |
| `react-hooks/set-state-in-effect` | ⏸️ Kept `off` | 6 violations across `useHydrated`, `useRelativeTime`, `useReferral`, `AdminAuditLog`, `AdminDashboard` — these are valid SSR hydration and data-fetch patterns |
| `react-hooks/preserve-manual-memoization` | ⏸️ Kept `off` | 2 violations in `useBalanceGuard` — intentional `.value` subproperty dep arrays |
| `react-hooks/incompatible-library` | ⏸️ Kept `off` | 1 violation — TanStack Table `useReactTable` is an upstream library constraint; requires tracking issue against `@tanstack/react-table` |

---

## Code Changes

Three inline tooltip components extracted to module scope to satisfy `static-components`:

**`AdminCharts.tsx`** — extracted `CustomTooltip` → `AdminChartTooltip` (module-level named function)

**`PerformanceCharts.tsx`** — extracted `EquityTooltip` to module-level; `isEstimated` closure variable converted to an explicit prop

**`PNLChart.tsx`** — extracted `CustomTooltip` → `PNLChartTooltip` (module-level named function)

---

## Validation

- **Lint:** `pnpm run lint` → 0 errors, 0 warnings ✅
- **Build:** `next build --webpack` → BUILD_OK ✅
  - Note: Turbopack build (`next build`) depends on PR #84 being merged first; `#83` changes do not touch any build config files

---

## Follow-up

The 4 deferred rules should each get their own issue for tracking. The highest-value next candidate is `purity` — once the `Date.now()` mock data is replaced with real data sources, the violations will naturally resolve.