### PR TITLE
chore(ui): migrate Next config to ESM and remove CJS lint exemption

### DIFF
--- a/packages/ui/eslint.config.mjs
+++ b/packages/ui/eslint.config.mjs
@@ -14,12 +14,6 @@ const config = [
       'react-hooks/purity': 'off',
       '@typescript-eslint/no-require-imports': 'error'
     }
-  },
-  {
-    files: ['next.config.js'],
-    rules: {
-      '@typescript-eslint/no-require-imports': 'off'
-    }
   }
 ];
 

--- a/packages/ui/next.config.mjs
+++ b/packages/ui/next.config.mjs
@@ -1,5 +1,8 @@
-/** @type {import('next').NextConfig} */
-const path = require('path');
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const nextConfig = {
   // Force all pages to render dynamically (SSR, not static)
@@ -65,4 +68,4 @@ const nextConfig = {
   output: process.env['NEXT_OUTPUT'] === 'standalone' ? 'standalone' : undefined
 };
 
-module.exports = nextConfig;
+export default nextConfig;


### PR DESCRIPTION
## Summary
- migrate UI Next.js config from CommonJS to ESM
- rename packages/ui/next.config.js -> packages/ui/next.config.mjs
- replace equire / module.exports with import / export default
- add ESM-safe __dirname handling via ileURLToPath(import.meta.url)
- remove now-obsolete scoped ESLint exemption in packages/ui/eslint.config.mjs

## Why
Issue #90 tracked the remaining CJS-based config exception left during prior lint hardening. Converting the config to ESM removes the need for the @typescript-eslint/no-require-imports file-specific override.

## Scope
- packages/ui/next.config.mjs (renamed from .js)
- packages/ui/eslint.config.mjs

No dependency changes, no unrelated refactors.

## Validation
- pnpm --dir packages/ui run lint ✅ (LINT_EXIT=0)
- pnpm --dir packages/ui run build ✅ (Turbopack build path)

Closes #90