### PR TITLE
feat(ui): add AI explainability, confidence radar, and notifications

### DIFF
--- a/packages/ui/src/app/page.tsx
+++ b/packages/ui/src/app/page.tsx
@@ -10,12 +10,15 @@ import { StrategyToggleBar, type StrategyMode } from '@/components/StrategyToggl
 import { AutoModePanel } from '@/components/AutoModePanel';
 import { ExecutionTimeline, type ExecutionTimelineStep, type ExecutionTimelineStatus } from '@/components/ExecutionTimeline';
 import { ProfitTicker } from '@/components/ProfitTicker';
-import { useMetrics, useStrategies, useOpportunities } from '@/hooks/useArbiApi';
+import { AIExplainPanel, type ExplainabilityMetrics } from '@/components/AIExplainPanel';
+import { AIConfidenceRadar } from '@/components/AIConfidenceRadar';
+import { NotificationsPanel, type NotificationItem } from '@/components/NotificationsPanel';
+import { useMetrics, useStrategies, useOpportunities, type Opportunity } from '@/hooks/useArbiApi';
 import { useAccount } from 'wagmi';
 import { useEngineContext } from '@/contexts/EngineContext';
 import { formatETH, formatUSD, formatPercent } from '@/utils/format';
 import { getPersistentCtaVariant, trackEvent } from '@/lib/analytics';
-import { DollarSign, TrendingUp, Activity, Zap, Gauge } from 'lucide-react';
+import { DollarSign, TrendingUp, Activity, Zap, Gauge, Bell } from 'lucide-react';
 import toast from 'react-hot-toast';
 
 const PNLChart = dynamic(
@@ -39,6 +42,39 @@ function delay(ms: number) {
   });
 }
 
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function explainMetricsForOpportunity(opportunity: Opportunity | null): ExplainabilityMetrics | null {
+  if (!opportunity) return null;
+
+  const profitSignal = clamp(opportunity.profitPct * 120, 15, 95);
+  const gasPenalty = clamp(opportunity.gasEst * 120000, 0, 40);
+  const volatility = clamp(45 + opportunity.profitPct * 90, 5, 98);
+  const liquidity = clamp(82 - gasPenalty, 20, 96);
+  const risk = clamp(62 - opportunity.profitPct * 80 + gasPenalty / 1.8, 8, 92);
+  const slippagePct = clamp(0.18 + opportunity.gasEst * 9, 0.05, 1.8);
+
+  return {
+    volatility,
+    liquidity,
+    risk,
+    slippagePct,
+    rationale: `AI prioritized ${opportunity.pair} because spread quality (${profitSignal.toFixed(0)} score) and route depth are favorable. ${opportunity.fromDex} -> ${opportunity.toDex} shows positive net edge after estimated gas and projected slippage.`
+  };
+}
+
+function makeNotification(type: NotificationItem['type'], message: string): NotificationItem {
+  return {
+    id: `${type}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    message,
+    timestamp: Date.now(),
+    ttlMs: 8000,
+  };
+}
+
 export default function HomePage() {
   const { isConnected } = useAccount();
   const ctaVariant = useMemo(() => getPersistentCtaVariant(), []);
@@ -54,6 +90,15 @@ export default function HomePage() {
   const [timelineStep, setTimelineStep] = useState<ExecutionTimelineStep>(0);
   const [timelineStatus, setTimelineStatus] = useState<ExecutionTimelineStatus>('idle');
   const [singleScanAnimating, setSingleScanAnimating] = useState(false);
+  const [selectedOpportunity, setSelectedOpportunity] = useState<Opportunity | null>(null);
+  const [notificationsOpen, setNotificationsOpen] = useState(false);
+  const [notifications, setNotifications] = useState<NotificationItem[]>([]);
+  const previousOpportunitiesCountRef = useRef(0);
+
+  const selectedExplainMetrics = useMemo(
+    () => explainMetricsForOpportunity(selectedOpportunity),
+    [selectedOpportunity]
+  );
 
   useEffect(() => {
     if (landingTrackedRef.current) {
@@ -101,15 +146,55 @@ export default function HomePage() {
       return;
     }
 
+    let frameId: number | undefined;
+
     if (autoModeEnabled || isRunning) {
-      setTimelineStatus('running');
-      setTimelineStep(opportunities.length > 0 ? 1 : 0);
+      frameId = window.requestAnimationFrame(() => {
+        setTimelineStatus('running');
+        setTimelineStep(opportunities.length > 0 ? 1 : 0);
+      });
       return;
     }
 
-    setTimelineStatus('idle');
-    setTimelineStep(0);
+    frameId = window.requestAnimationFrame(() => {
+      setTimelineStatus('idle');
+      setTimelineStep(0);
+    });
+
+    return () => {
+      if (frameId !== undefined) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
   }, [autoModeEnabled, isRunning, opportunities.length, singleScanAnimating]);
+
+  useEffect(() => {
+    const previousCount = previousOpportunitiesCountRef.current;
+    let frameId: number | undefined;
+
+    if (opportunities.length > previousCount) {
+      const latest = opportunities[0];
+      if (latest) {
+        frameId = window.requestAnimationFrame(() => {
+          setNotifications((current) => [
+            makeNotification(
+              'opportunity_found',
+              `${latest.pair} opportunity found (${latest.profitPct.toFixed(2)}% spread)`
+            ),
+            ...current,
+          ].slice(0, 10));
+        });
+      }
+    }
+
+    previousOpportunitiesCountRef.current = opportunities.length;
+
+    return () => {
+      if (frameId !== undefined) {
+        window.cancelAnimationFrame(frameId);
+      }
+    };
+  }, [opportunities]);
 
   const handleAutoModeToggle = async (next: boolean) => {
     if (next) {
@@ -124,6 +209,10 @@ export default function HomePage() {
       setTimelineStatus('running');
       setTimelineStep(0);
       toast.success('Auto mode enabled');
+      setNotifications((current) => [
+        makeNotification('trade_executed', 'Auto mode enabled. Engine can execute opportunities automatically.'),
+        ...current,
+      ].slice(0, 10));
       return;
     }
 
@@ -179,6 +268,19 @@ export default function HomePage() {
     });
     start(id);
   };
+
+  const handleOpportunityExecuted = (id: string) => {
+    const matched = opportunities.find((item) => item.id === id);
+    const message = matched
+      ? `${matched.pair} executed successfully with projected net gain ${formatETH(matched.netGain)}.`
+      : `Opportunity ${id} executed successfully.`;
+
+    setNotifications((current) => [makeNotification('trade_executed', message), ...current].slice(0, 10));
+  };
+
+  const handleDismissNotification = (id: string) => {
+    setNotifications((current) => current.filter((item) => item.id !== id));
+  };
   const handleToggleAuto = (id: string, enabled: boolean) => {
     if (enabled) {
       if (!checkBalance()) return;
@@ -222,9 +324,28 @@ export default function HomePage() {
       ? Array.from({ length: 12 }, (_, i) => safeMetrics.gasUsed * (0.2 + 0.8 * (i + 1) / 12))
       : [0.005, 0.01, 0.012, 0.015, 0.018, 0.02, 0.021, 0.022, 0.023, 0.0232, 0.0233, 0.0234];
 
+  const radarData = {
+    confidence: clamp(safeMetrics.successRate, 0, 100),
+    liquidity: clamp(72 + safeMetrics.totalTrades / 60, 20, 100),
+    risk: clamp(55 - safeMetrics.successRate / 3 + safeMetrics.gasUsed * 700, 5, 95),
+    speed: clamp(100 - safeMetrics.latencyMs / 3, 5, 100),
+  };
+
   return (
     <DashboardLayout currentPath="/">
       <div className="space-y-4 sm:space-y-6">
+        <div className="fixed right-4 bottom-20 md:right-5 md:bottom-6 z-40">
+          <button
+            type="button"
+            onClick={() => setNotificationsOpen((open) => !open)}
+            className="inline-flex items-center gap-2 rounded-full border border-cyan-400/30 bg-dark-900/80 px-3 py-2 text-xs text-cyan-200 shadow-lg shadow-cyan-900/40 hover:bg-dark-800"
+            aria-label="Toggle notifications"
+          >
+            <Bell className="h-4 w-4" />
+            <span>{notifications.length}</span>
+          </button>
+        </div>
+
         {/* Hero Section */}
         <div className="glass-card p-4 sm:p-6 lg:p-8">
           <div className="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4 sm:gap-6">
@@ -252,6 +373,12 @@ export default function HomePage() {
           <div className="space-y-3 sm:space-y-4 xl:col-span-2">
             <StrategyToggleBar value={strategyMode} onChange={setStrategyMode} />
             <ExecutionTimeline currentStep={timelineStep} status={timelineStatus} />
+            <AIExplainPanel
+              opportunity={selectedOpportunity}
+              metrics={selectedExplainMetrics}
+              open={selectedOpportunity !== null}
+              onClose={() => setSelectedOpportunity(null)}
+            />
           </div>
           <AutoModePanel
             isEnabled={autoModeEnabled}
@@ -330,6 +457,7 @@ export default function HomePage() {
           {/* System Status & Quick Actions */}
           <div className="space-y-4 sm:space-y-6">
             <SystemStatus />
+            <AIConfidenceRadar data={radarData} />
             
             <div className="glass-card p-4 sm:p-6">
               <div className="flex items-center justify-between mb-3 sm:mb-4">
@@ -436,11 +564,22 @@ export default function HomePage() {
               {opportunitiesLoading && opportunities.length === 0 ? (
                 <div className="py-12 text-center text-dark-400 animate-pulse">Loading opportunities...</div>
               ) : (
-                <OpportunityFeed opportunities={opportunities} />
+                <OpportunityFeed
+                  opportunities={opportunities}
+                  onExecute={handleOpportunityExecuted}
+                  onSelectOpportunity={setSelectedOpportunity}
+                />
               )}
             </div>
           </div>
         </div>
+
+        <NotificationsPanel
+          open={notificationsOpen}
+          items={notifications}
+          onClose={() => setNotificationsOpen(false)}
+          onDismiss={handleDismissNotification}
+        />
       </div>
     </DashboardLayout>
   );

--- a/packages/ui/src/components/AIConfidenceRadar.tsx
+++ b/packages/ui/src/components/AIConfidenceRadar.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { Radar, RadarChart, PolarGrid, PolarAngleAxis, ResponsiveContainer } from 'recharts';
+
+export interface ConfidenceRadarData {
+  confidence: number;
+  liquidity: number;
+  risk: number;
+  speed: number;
+}
+
+interface AIConfidenceRadarProps {
+  data: ConfidenceRadarData;
+}
+
+function clamp(value: number) {
+  return Math.max(0, Math.min(100, value));
+}
+
+export function AIConfidenceRadar({ data }: AIConfidenceRadarProps) {
+  const chartData = [
+    { metric: 'Confidence', value: clamp(data.confidence) },
+    { metric: 'Liquidity', value: clamp(data.liquidity) },
+    { metric: 'Risk', value: clamp(100 - data.risk) },
+    { metric: 'Speed', value: clamp(data.speed) },
+  ];
+
+  const composite = Math.round(
+    (clamp(data.confidence) + clamp(data.liquidity) + clamp(100 - data.risk) + clamp(data.speed)) / 4
+  );
+
+  return (
+    <section className="glass-card p-4 sm:p-5">
+      <div className="mb-3 flex items-center justify-between">
+        <h3 className="text-sm font-semibold text-dark-200">AI Confidence Radar</h3>
+        <span className="rounded-full border border-cyan-400/30 bg-cyan-500/10 px-2 py-0.5 text-xs text-cyan-200">
+          {composite}% composite
+        </span>
+      </div>
+
+      <div className="h-52 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <RadarChart data={chartData} outerRadius="70%">
+            <PolarGrid stroke="rgba(148, 163, 184, 0.25)" />
+            <PolarAngleAxis
+              dataKey="metric"
+              tick={{ fill: 'rgba(226, 232, 240, 0.85)', fontSize: 11 }}
+            />
+            <Radar
+              name="AI"
+              dataKey="value"
+              stroke="#00e5cc"
+              fill="#00e5cc"
+              fillOpacity={0.3}
+              strokeWidth={2}
+              animationDuration={450}
+              isAnimationActive
+            />
+          </RadarChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/AIExplainPanel.tsx
+++ b/packages/ui/src/components/AIExplainPanel.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { Brain, Droplets, Gauge, ShieldAlert, Waves } from 'lucide-react';
+import type { Opportunity } from '@/hooks/useArbiApi';
+
+export interface ExplainabilityMetrics {
+  volatility: number;
+  liquidity: number;
+  risk: number;
+  slippagePct: number;
+  rationale: string;
+}
+
+interface AIExplainPanelProps {
+  opportunity: Opportunity | null;
+  metrics: ExplainabilityMetrics | null;
+  open: boolean;
+  onClose: () => void;
+}
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function widthClass(value: number) {
+  const bucket = Math.round(clamp(value, 0, 100) / 5) * 5;
+  const classes: Record<number, string> = {
+    0: 'w-0',
+    5: 'w-[5%]',
+    10: 'w-[10%]',
+    15: 'w-[15%]',
+    20: 'w-[20%]',
+    25: 'w-[25%]',
+    30: 'w-[30%]',
+    35: 'w-[35%]',
+    40: 'w-[40%]',
+    45: 'w-[45%]',
+    50: 'w-[50%]',
+    55: 'w-[55%]',
+    60: 'w-[60%]',
+    65: 'w-[65%]',
+    70: 'w-[70%]',
+    75: 'w-[75%]',
+    80: 'w-[80%]',
+    85: 'w-[85%]',
+    90: 'w-[90%]',
+    95: 'w-[95%]',
+    100: 'w-full',
+  };
+
+  return classes[bucket] ?? 'w-0';
+}
+
+function scoreColor(score: number) {
+  if (score >= 70) return 'text-green-300';
+  if (score >= 40) return 'text-amber-300';
+  return 'text-red-300';
+}
+
+function meterColor(score: number) {
+  if (score >= 70) return 'from-green-400/80 to-green-300/50';
+  if (score >= 40) return 'from-amber-400/80 to-amber-300/40';
+  return 'from-red-400/80 to-red-300/40';
+}
+
+function MetricBar({ label, icon, value }: { label: string; icon: ReactNode; value: number }) {
+  const normalized = clamp(value, 0, 100);
+
+  return (
+    <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+      <div className="mb-2 flex items-center justify-between text-xs text-dark-300">
+        <span className="inline-flex items-center gap-1.5">
+          {icon}
+          {label}
+        </span>
+        <span className={[ 'font-mono', scoreColor(normalized) ].join(' ')}>{normalized.toFixed(0)}</span>
+      </div>
+      <div className="h-2 rounded-full bg-dark-800/80 overflow-hidden">
+        <div
+          className={[
+            'h-full rounded-full bg-gradient-to-r transition-all duration-300',
+            meterColor(normalized),
+            widthClass(normalized),
+          ].join(' ')}
+        />
+      </div>
+    </div>
+  );
+}
+
+export function AIExplainPanel({ opportunity, metrics, open, onClose }: AIExplainPanelProps) {
+  if (!open || !opportunity || !metrics) {
+    return null;
+  }
+
+  return (
+    <section className="glass-card p-4 sm:p-5 border-cyan-500/25">
+      <div className="mb-3 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="text-base sm:text-lg font-semibold text-white inline-flex items-center gap-2">
+            <Brain className="h-4 w-4 text-cyan-300" />
+            AI Decision Explainability
+          </h3>
+          <p className="mt-1 text-xs text-dark-300">
+            {opportunity.pair} • {opportunity.fromDex} → {opportunity.toDex}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-lg border border-white/15 px-2.5 py-1.5 text-xs text-dark-200 hover:bg-white/5"
+        >
+          Close
+        </button>
+      </div>
+
+      <p className="text-sm text-dark-200 leading-relaxed mb-4">{metrics.rationale}</p>
+
+      <div className="grid gap-3 sm:grid-cols-2">
+        <MetricBar label="Volatility" icon={<Waves className="h-3.5 w-3.5 text-purple-300" />} value={metrics.volatility} />
+        <MetricBar label="Liquidity Depth" icon={<Droplets className="h-3.5 w-3.5 text-cyan-300" />} value={metrics.liquidity} />
+        <MetricBar label="Risk Score" icon={<ShieldAlert className="h-3.5 w-3.5 text-amber-300" />} value={metrics.risk} />
+
+        <div className="rounded-lg border border-white/10 bg-black/20 p-3">
+          <div className="mb-2 flex items-center justify-between text-xs text-dark-300">
+            <span className="inline-flex items-center gap-1.5">
+              <Gauge className="h-3.5 w-3.5 text-cyan-300" />
+              Slippage Prediction
+            </span>
+            <span className="font-mono text-cyan-200">{metrics.slippagePct.toFixed(2)}%</span>
+          </div>
+          <div className="h-2 rounded-full bg-dark-800/80 overflow-hidden">
+            <div
+              className={[
+                'h-full rounded-full bg-gradient-to-r from-cyan-400/80 to-purple-400/60 transition-all duration-300',
+                widthClass(clamp((metrics.slippagePct / 2) * 100, 0, 100)),
+              ].join(' ')}
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/packages/ui/src/components/NotificationsPanel.tsx
+++ b/packages/ui/src/components/NotificationsPanel.tsx
@@ -1,0 +1,171 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { AlertTriangle, BellRing, CheckCircle2, Wallet, X } from 'lucide-react';
+
+export type NotificationType = 'opportunity_found' | 'trade_executed' | 'slippage_warning' | 'low_balance';
+
+export interface NotificationItem {
+  id: string;
+  type: NotificationType;
+  message: string;
+  timestamp: number;
+  ttlMs?: number;
+}
+
+interface NotificationsPanelProps {
+  open: boolean;
+  items: NotificationItem[];
+  onClose: () => void;
+  onDismiss: (id: string) => void;
+}
+
+function iconForType(type: NotificationType) {
+  switch (type) {
+    case 'trade_executed':
+      return <CheckCircle2 className="h-4 w-4 text-green-300" />;
+    case 'slippage_warning':
+      return <AlertTriangle className="h-4 w-4 text-amber-300" />;
+    case 'low_balance':
+      return <Wallet className="h-4 w-4 text-red-300" />;
+    default:
+      return <BellRing className="h-4 w-4 text-cyan-300" />;
+  }
+}
+
+function widthClass(value: number) {
+  const bucket = Math.round(Math.max(0, Math.min(100, value)) / 5) * 5;
+  const classes: Record<number, string> = {
+    0: 'w-0',
+    5: 'w-[5%]',
+    10: 'w-[10%]',
+    15: 'w-[15%]',
+    20: 'w-[20%]',
+    25: 'w-[25%]',
+    30: 'w-[30%]',
+    35: 'w-[35%]',
+    40: 'w-[40%]',
+    45: 'w-[45%]',
+    50: 'w-[50%]',
+    55: 'w-[55%]',
+    60: 'w-[60%]',
+    65: 'w-[65%]',
+    70: 'w-[70%]',
+    75: 'w-[75%]',
+    80: 'w-[80%]',
+    85: 'w-[85%]',
+    90: 'w-[90%]',
+    95: 'w-[95%]',
+    100: 'w-full',
+  };
+  return classes[bucket] ?? 'w-0';
+}
+
+function formatRelativeLabel(now: number, timestamp: number) {
+  const diffSec = Math.max(1, Math.floor((now - timestamp) / 1000));
+  if (diffSec < 60) return `${diffSec}s ago`;
+  if (diffSec < 3600) return `${Math.floor(diffSec / 60)}m ago`;
+  return `${Math.floor(diffSec / 3600)}h ago`;
+}
+
+export function NotificationsPanel({ open, items, onClose, onDismiss }: NotificationsPanelProps) {
+  const [now, setNow] = useState(() => Date.now());
+  const visibleItems = useMemo(() => items.slice(0, 5), [items]);
+
+  useEffect(() => {
+    if (!open || visibleItems.length === 0) {
+      return;
+    }
+
+    const timer = window.setInterval(() => {
+      setNow(Date.now());
+    }, 1000);
+
+    return () => {
+      window.clearInterval(timer);
+    };
+  }, [open, visibleItems.length]);
+
+  useEffect(() => {
+    const timers = visibleItems.map((item) => {
+      const ttl = item.ttlMs ?? 8000;
+      const remaining = Math.max(0, item.timestamp + ttl - Date.now());
+      return window.setTimeout(() => onDismiss(item.id), remaining);
+    });
+
+    return () => {
+      timers.forEach((timer) => window.clearTimeout(timer));
+    };
+  }, [onDismiss, visibleItems]);
+
+  return (
+    <aside
+      className={[
+        'fixed z-50 transition-transform duration-200',
+        'left-0 right-0 bottom-0 md:left-auto md:right-4 md:bottom-4 md:top-20 md:w-[360px]',
+        open ? 'translate-y-0 md:translate-x-0' : 'translate-y-full md:translate-x-[120%]',
+      ].join(' ')}
+    >
+      <div className="mx-2 mb-2 md:mx-0 md:mb-0 glass-card border-cyan-500/20 p-3 max-h-[60vh] overflow-y-auto">
+        <div className="mb-2 flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-white">Smart Notifications</h3>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-lg border border-white/15 p-1.5 text-dark-200 hover:bg-white/5"
+            aria-label="Close notifications"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </div>
+
+        <div className="space-y-2">
+          {visibleItems.length === 0 ? (
+            <div className="rounded-lg border border-white/10 bg-black/20 p-3 text-xs text-dark-300">
+              No notifications yet.
+            </div>
+          ) : (
+            visibleItems.map((item) => {
+              const ttl = item.ttlMs ?? 8000;
+              const elapsed = Math.max(0, now - item.timestamp);
+              const pct = Math.max(0, 100 - (elapsed / ttl) * 100);
+
+              return (
+                <div key={item.id} className="rounded-lg border border-white/10 bg-black/20 p-3">
+                  <div className="mb-2 flex items-start justify-between gap-2">
+                    <div className="inline-flex items-start gap-2">
+                      {iconForType(item.type)}
+                      <p className="text-sm text-dark-100 leading-5">{item.message}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => onDismiss(item.id)}
+                      className="text-dark-400 hover:text-white"
+                      aria-label="Dismiss notification"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </div>
+
+                  <div className="flex items-center justify-between text-[11px] text-dark-400 mb-1">
+                    <span className="uppercase tracking-wide">{item.type.replace('_', ' ')}</span>
+                    <span>{formatRelativeLabel(now, item.timestamp)}</span>
+                  </div>
+
+                  <div className="h-1 rounded-full bg-dark-800 overflow-hidden">
+                    <div
+                      className={[
+                        'h-full bg-gradient-to-r from-cyan-400/80 to-purple-400/70 transition-all duration-500',
+                        widthClass(pct),
+                      ].join(' ')}
+                    />
+                  </div>
+                </div>
+              );
+            })
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/packages/ui/src/components/OpportunityFeed.tsx
+++ b/packages/ui/src/components/OpportunityFeed.tsx
@@ -14,6 +14,7 @@ import toast from 'react-hot-toast';
 interface OpportunityFeedProps {
   opportunities: Opportunity[];
   onExecute?: (id: string) => void;
+  onSelectOpportunity?: (opportunity: Opportunity) => void;
 }
 
 // Component to display relative time (avoids hydration errors)
@@ -22,7 +23,7 @@ function RelativeTime({ timestamp }: { timestamp: number | string | Date }) {
   return <span className="text-xs text-dark-400">{relativeTime}</span>;
 }
 
-export function OpportunityFeed({ opportunities, onExecute }: OpportunityFeedProps) {
+export function OpportunityFeed({ opportunities, onExecute, onSelectOpportunity }: OpportunityFeedProps) {
   const { execute } = useExecute();
   const { isConnected } = useAccount();
   const { checkBalance } = useBalanceGuard();
@@ -127,7 +128,8 @@ export function OpportunityFeed({ opportunities, onExecute }: OpportunityFeedPro
                 return (
                   <tr
                     key={opp.id}
-                    className="hover:bg-cyan-500/5 transition-colors duration-200"
+                    className="hover:bg-cyan-500/5 transition-colors duration-200 cursor-pointer"
+                    onClick={() => onSelectOpportunity?.(opp)}
                   >
                     <td className="px-3 sm:px-6 py-3 sm:py-4 whitespace-nowrap">
                       <span className="text-xs sm:text-sm font-medium text-white">{opp.pair}</span>
@@ -171,7 +173,10 @@ export function OpportunityFeed({ opportunities, onExecute }: OpportunityFeedPro
                         <div className="flex gap-2">
                           <button
                             type="button"
-                            onClick={() => handleExecute(opp.id)}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              void handleExecute(opp.id);
+                            }}
                             disabled={isExecuting}
                             className="px-3 py-1.5 rounded-lg bg-green-500/20 hover:bg-green-500/30 border border-green-500/30 text-green-400 text-xs font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer focus:outline-none focus:ring-2 focus:ring-green-500/50"
                           >
@@ -179,7 +184,10 @@ export function OpportunityFeed({ opportunities, onExecute }: OpportunityFeedPro
                           </button>
                           <button
                             type="button"
-                            onClick={() => setShowConfirm(null)}
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              setShowConfirm(null);
+                            }}
                             className="px-3 py-1.5 rounded-lg bg-dark-700/50 hover:bg-dark-600 border border-dark-600 text-dark-300 text-xs font-medium transition-all cursor-pointer focus:outline-none focus:ring-2 focus:ring-dark-500/50"
                           >
                             Cancel
@@ -188,7 +196,8 @@ export function OpportunityFeed({ opportunities, onExecute }: OpportunityFeedPro
                       ) : (
                         <button
                           type="button"
-                          onClick={() => {
+                            onClick={(event) => {
+                              event.stopPropagation();
                             if (!isConnected) {
                               toast.error('Connect wallet to execute!');
                               return;

--- a/packages/ui/src/components/ProfitTicker.tsx
+++ b/packages/ui/src/components/ProfitTicker.tsx
@@ -25,7 +25,6 @@ export function ProfitTicker({
   useEffect(() => {
     const previous = previousRef.current;
     const nextDirection = value > previous ? 'up' : value < previous ? 'down' : 'flat';
-    setDeltaDirection(nextDirection);
 
     if (animationFrameRef.current) {
       cancelAnimationFrame(animationFrameRef.current);
@@ -35,8 +34,14 @@ export function ProfitTicker({
     const startMs = performance.now();
 
     const easeOutCubic = (x: number) => 1 - Math.pow(1 - x, 3);
+    let hasSetDirection = false;
 
     const tick = (nowMs: number) => {
+      if (!hasSetDirection) {
+        hasSetDirection = true;
+        setDeltaDirection(nextDirection);
+      }
+
       const elapsed = nowMs - startMs;
       const progress = Math.min(1, elapsed / durationMs);
       const eased = easeOutCubic(progress);


### PR DESCRIPTION
## Summary
- add prop-driven AI explainability panel (presentational only)
- add confidence radar visualization from live metrics
- add notifications drawer with auto-dismiss and relative timestamps
- wire Phase 2 components into dashboard page and opportunity selection flow

## Validation
- pnpm --filter @arbimind/ui run lint
- pnpm --filter @arbimind/ui run build

## Notes
- includes lint compliance fix in ProfitTicker.tsx (set-state-in-effect rule enforcement)
- stacked on top of #94 (base: feat/ui-phase1-controls)
