### PR TITLE
fix(ui): split mobile wallet paths and allow Solana RPC in CSP

### DIFF
--- a/packages/ui/src/app/solana-wallet/SolanaWalletPageClient.tsx
+++ b/packages/ui/src/app/solana-wallet/SolanaWalletPageClient.tsx
@@ -26,8 +26,13 @@ const SOLANA_TREASURY_ADDRESS =
   process.env.NEXT_PUBLIC_SOLANA_ARB_ACCOUNT || '6wmAm8uoPQTx9jEnGx4aDKwVFRSfdhKJfL2LJzwCmE6s';
 // Override only the states that display the CTA text so it never regresses to "Select Wallet".
 const SOLANA_WALLET_BUTTON_LABELS = {
-  'has-wallet': 'Connect Wallet',
-  'no-wallet': 'Connect Wallet',
+  'has-wallet': 'Connect Solana',
+  'no-wallet': 'Connect Solana',
+  connecting: 'Connecting...',
+  'copy-address': 'Copy address',
+  copied: 'Copied',
+  'change-wallet': 'Change wallet',
+  disconnect: 'Disconnect',
 } as const;
 
 type BotTrade = {
@@ -385,7 +390,7 @@ export default function SolanaWalletPageClient() {
           }>;
         };
 
-        const normalized = (payload.trades ?? [])
+        const normalized: BotTrade[] = (payload.trades ?? [])
           .filter((trade) => !!trade.id)
           .map((trade) => ({
             id: trade.id as string,
@@ -988,7 +993,7 @@ export default function SolanaWalletPageClient() {
               </p>
               <div className="flex flex-wrap gap-2 mt-2 justify-center lg:justify-start">
                 <span className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-gradient-to-r from-purple-600/80 to-pink-500/80 text-xs font-semibold text-white shadow-sm">
-                  <Wallet className="w-4 h-4" /> Wallet Connect
+                  <Wallet className="w-4 h-4" /> Solana Wallet
                 </span>
                 <span className="inline-flex items-center gap-1 px-3 py-1.5 rounded-full bg-gradient-to-r from-cyan-500/80 to-blue-400/80 text-xs font-semibold text-white shadow-sm">
                   <ArrowRightLeft className="w-4 h-4" /> Instant Swaps
@@ -1017,11 +1022,17 @@ export default function SolanaWalletPageClient() {
                   >
                     Connect Solflare
                   </button>
+                  <Link
+                    href="/wallet"
+                    className="px-4 py-2 rounded-lg bg-dark-800/80 hover:bg-dark-700 border border-dark-600 text-white text-sm font-semibold transition"
+                  >
+                    Open EVM Wallet
+                  </Link>
                 </div>
               )}
               {!isSolanaConnected && (
                 <p className="text-xs text-dark-400 mt-2 max-w-md text-center lg:text-left">
-                  The top-right <span className="font-mono">0x...</span> wallet is EVM. For this page, connect Phantom/Solflare using the button above.
+                  The top-right <span className="font-mono">0x...</span> wallet is EVM. Use Connect Solana, Phantom, or Solflare here, or switch back to the EVM wallet page.
                 </p>
               )}
               <p className="text-xs text-dark-400/90 mt-2 max-w-md text-center lg:text-left">
@@ -1160,7 +1171,9 @@ export default function SolanaWalletPageClient() {
                   </div>
                 </div>
               )}
-              {/* Connect using the hero button above */}
+              <p className="text-sm text-dark-400">
+                Use the primary wallet controls above to connect Phantom or Solflare, or return to the EVM wallet page.
+              </p>
             </motion.div>
 
             <motion.div
@@ -1170,7 +1183,7 @@ export default function SolanaWalletPageClient() {
             >
               <div className="glass-card p-4 sm:p-5 opacity-90">
                 <h2 className="text-sm font-medium text-dark-300 mb-2">Your SOL Balance</h2>
-                <p className="text-2xl font-bold text-white">Connect wallet</p>
+                <p className="text-2xl font-bold text-white">Connect Solana</p>
               </div>
               <div className="glass-card p-4 sm:p-5 opacity-90">
                 <h2 className="text-sm font-medium text-dark-300 mb-2">Bot Treasury Balance</h2>

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -53,7 +53,7 @@ export function Header() {
           {!isConnected && (
             <span className="hidden md:block text-xs text-cyan-300/90">{ctaLabel}</span>
           )}
-          <div
+          <div className="hidden sm:block"
             onClickCapture={() => {
               if (!isConnected) {
                 trackEvent('wallet_connect_click', {
@@ -65,6 +65,41 @@ export function Header() {
             }}
           >
             <ConnectButton accountStatus="address" chainStatus="icon" showBalance={false} />
+          </div>
+          <div className="flex items-center gap-2 sm:hidden">
+            <ConnectButton.Custom>
+              {({ account, mounted, openAccountModal, openConnectModal }) => {
+                const ready = mounted;
+                const connected = ready && !!account;
+
+                return (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      if (!connected) {
+                        trackEvent('wallet_connect_click', {
+                          source: 'header_mobile_evm_button',
+                          ctaVariant,
+                          pathname,
+                        });
+                        openConnectModal?.();
+                        return;
+                      }
+                      openAccountModal?.();
+                    }}
+                    className="rounded-lg border border-cyan-400/30 bg-cyan-400/10 px-3 py-2 text-xs font-semibold text-cyan-200 transition hover:bg-cyan-400/20"
+                  >
+                    {connected ? 'EVM Wallet' : 'Connect EVM'}
+                  </button>
+                );
+              }}
+            </ConnectButton.Custom>
+            <Link
+              href="/solana-wallet"
+              className="rounded-lg border border-purple-400/30 bg-purple-400/10 px-3 py-2 text-xs font-semibold text-purple-200 transition hover:bg-purple-400/20"
+            >
+              Solana
+            </Link>
           </div>
         </div>
       </div>

--- a/packages/ui/src/middleware.ts
+++ b/packages/ui/src/middleware.ts
@@ -44,10 +44,14 @@ export function middleware(req: NextRequest) {
       toOrigin(process.env.NEXT_PUBLIC_AMOY_RPC_URL),
       toOrigin(process.env.NEXT_PUBLIC_POLYGON_AMOY_RPC_URL),
       toOrigin(process.env.NEXT_PUBLIC_POLYGON_AMOY_RPC),
+      toOrigin(process.env.NEXT_PUBLIC_SOLANA_RPC_URL),
       'https://polygon-rpc.com',
       'https://rpc-amoy.polygon.technology',
       'https://polygon-amoy.publicnode.com',
       'https://polygon-bor-rpc.publicnode.com',
+      'https://api.devnet.solana.com',
+      'https://api.mainnet-beta.solana.com',
+      'https://api.testnet.solana.com',
       'https://*.alchemy.com',
     ].filter(Boolean);
 


### PR DESCRIPTION
﻿## Summary
- split mobile wallet actions into explicit EVM and Solana paths
- make the Solana disconnected flow explicit with Solana-specific wallet choices and EVM return path
- allow Solana RPC endpoints in UI CSP connect-src

## Files
- packages/ui/src/components/Header.tsx
- packages/ui/src/app/solana-wallet/SolanaWalletPageClient.tsx
- packages/ui/src/middleware.ts

## Notes
- keeps wallet-path UX scoped to the active mobile flow
- adds CSP allowlist entries for devnet, mainnet-beta, testnet, and optional NEXT_PUBLIC_SOLANA_RPC_URL origin
- intentionally excludes unrelated wallet page changes

## Validation
- targeted ESLint passed for touched UI files
