### PR TITLE
fix(security): add explicit permissions to post-deploy smoke workflow

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: "false"
 
+permissions:
+  contents: read
+
 jobs:
   smoke:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}


### PR DESCRIPTION
Resolves CodeQL alert actions/missing-workflow-permissions on .github/workflows/post-deploy-smoke.yml.

Adds explicit least-privilege workflow permissions:

`yaml
permissions:
  contents: read
`

This prevents fallback to repository/org default GITHUB_TOKEN permissions and aligns with least privilege.