### PR TITLE
ci(deploy): add workflow_dispatch to enable manual UI deployments

### DIFF
--- a/.github/workflows/deploy-ui.yml
+++ b/.github/workflows/deploy-ui.yml
@@ -2,6 +2,7 @@ name: Deploy UI to Vercel
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes the inability to manually trigger Vercel redeployments.

- Adds \workflow_dispatch\ trigger to deploy-ui.yml
- Allows: \gh workflow run deploy-ui.yml --repo rigocrypto/arbimind --ref main\
- Automatically triggers this PR change, which will redeploy with latest main routes