### PR TITLE
fix(ui): restore footer and remove broken mobile footer bar

### DIFF
--- a/packages/ui/src/app/layout.tsx
+++ b/packages/ui/src/app/layout.tsx
@@ -7,7 +7,6 @@ import { Providers } from '@/components/Providers'
 import { Footer } from '@/components/Footer'
 import { Header } from '@/components/Header'
 import { PromotionBanner } from '@/components/PromotionBanner'
-import { MobileBottomBar } from '@/components/Layout/MobileBottomBar'
 import ClientOnly from '@/components/ClientOnly';
 
 const inter = Inter({ subsets: ['latin'], variable: '--font-inter' })
@@ -25,7 +24,7 @@ export const metadata: Metadata = {
   keywords: ['arbitrage', 'mev', 'defi', 'ethereum', 'dex', 'trading'],
   authors: [{ name: 'ArbiMind Team' }],
   icons: {
-    icon: '/ArbiMind-Logo-1.svg',
+    icon: '/favicon.svg',
     apple: '/apple-touch-icon.png',
   },
 }
@@ -68,12 +67,11 @@ export default function RootLayout({
                 <div className="relative z-20">
                   <Header />
                 </div>
-                <main className="flex-1 flex flex-col min-h-0 pt-16 pb-16 relative z-10">
+                <main className="flex-1 flex flex-col min-h-0 pt-16 relative z-10">
                   <Suspense fallback={<LoadingFallback />}>
                     {children}
                   </Suspense>
                 </main>
-                <MobileBottomBar />
                 <Footer />
               </Providers>
             </ClientOnly>

--- a/packages/ui/src/components/Footer.tsx
+++ b/packages/ui/src/components/Footer.tsx
@@ -2,9 +2,10 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Github as GithubIcon } from 'lucide-react';
+import { Github as GithubIcon, LifeBuoy, ShieldCheck } from 'lucide-react';
 
 const GITHUB_URL = 'https://github.com/rigocrypto/arbimind';
+const SUPPORT_URL = 'https://github.com/rigocrypto/arbimind/issues';
 
 function FooterLink({
   href,
@@ -30,28 +31,84 @@ function FooterLink({
 
 export function Footer() {
   return (
-    <footer className="border-t border-white/10 bg-black/20 relative z-20">
-      <div className="max-w-7xl mx-auto px-3 sm:px-4 lg:px-8 py-6 sm:py-8">
-        <div className="flex flex-col md:flex-row items-center justify-between gap-4">
-          <div className="text-sm text-dark-400">
-            © {new Date().getFullYear()} ArbiMind
+    <footer className="relative z-20 border-t border-white/10 bg-black/30 backdrop-blur-xl">
+      <div className="mx-auto max-w-7xl px-4 py-10 sm:px-6 lg:px-8">
+        <div className="grid gap-10 lg:grid-cols-[1.2fr_repeat(3,minmax(0,1fr))]">
+          <div className="space-y-4">
+            <div>
+              <p className="text-lg font-semibold text-white">ArbiMind</p>
+              <p className="mt-2 max-w-sm text-sm leading-6 text-dark-300">
+                Live arbitrage intelligence for monitoring routes, connecting wallets, and operating faster across EVM and Solana flows.
+              </p>
+            </div>
+            <div className="flex flex-wrap items-center gap-3 text-sm text-dark-300">
+              <a
+                href={GITHUB_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition-colors hover:text-white"
+              >
+                <GithubIcon className="h-4 w-4" aria-hidden />
+                GitHub
+              </a>
+              <a
+                href={SUPPORT_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1.5 transition-colors hover:text-white"
+              >
+                <LifeBuoy className="h-4 w-4" aria-hidden />
+                Support
+              </a>
+            </div>
           </div>
 
-          <nav className="flex flex-wrap items-center gap-x-6 gap-y-2 text-sm" aria-label="Footer">
-            <a
-              href={GITHUB_URL}
-              target="_blank"
-              rel="noreferrer noopener"
-              className="flex items-center gap-1.5 text-dark-400 hover:text-white transition-colors"
-              aria-label="ArbiMind on GitHub"
-            >
-              <GithubIcon className="w-4 h-4" aria-hidden />
-              GitHub
-            </a>
-            <FooterLink href="/docs">Docs</FooterLink>
-            <FooterLink href="/terms" exact>Terms</FooterLink>
-            <FooterLink href="/privacy" exact>Privacy</FooterLink>
+          <nav className="space-y-3" aria-label="Product footer links">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/55">Product</p>
+            <div className="flex flex-col gap-2 text-sm">
+              <FooterLink href="/settings" exact>Settings</FooterLink>
+              <FooterLink href="/wallet" exact>EVM Wallet</FooterLink>
+              <FooterLink href="/solana-wallet" exact>Solana Wallet</FooterLink>
+              <FooterLink href="/history">History</FooterLink>
+            </div>
           </nav>
+
+          <nav className="space-y-3" aria-label="Resources footer links">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/55">Resources</p>
+            <div className="flex flex-col gap-2 text-sm">
+              <FooterLink href="/docs">Docs</FooterLink>
+              <FooterLink href="/feed">Live Feed</FooterLink>
+              <FooterLink href="/strategies">Strategies</FooterLink>
+              <FooterLink href="/pro">Pro Access</FooterLink>
+            </div>
+          </nav>
+
+          <nav className="space-y-3" aria-label="Company footer links">
+            <p className="text-xs font-semibold uppercase tracking-[0.18em] text-white/55">Trust</p>
+            <div className="flex flex-col gap-2 text-sm">
+              <FooterLink href="/terms" exact>Terms</FooterLink>
+              <FooterLink href="/privacy" exact>Privacy</FooterLink>
+              <a
+                href={SUPPORT_URL}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="inline-flex items-center gap-2 text-dark-400 transition-colors hover:text-white"
+              >
+                <ShieldCheck className="h-4 w-4" aria-hidden />
+                Report an issue
+              </a>
+            </div>
+          </nav>
+        </div>
+
+        <div className="mt-8 flex flex-col gap-3 border-t border-white/10 pt-5 text-xs text-dark-400 sm:flex-row sm:items-center sm:justify-between">
+          <div>© {new Date().getFullYear()} ArbiMind. Built for fast on-chain execution.</div>
+          <div className="flex items-center gap-4">
+            <span>Production status visible in nightly smoke monitoring.</span>
+            <Link href="/docs" className="text-dark-300 transition-colors hover:text-white">
+              Deployment docs
+            </Link>
+          </div>
         </div>
       </div>
     </footer>

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -57,8 +57,6 @@ export function Header() {
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
   const [isWalletModalOpen, setIsWalletModalOpen] = useState(false);
   const [solanaAddress, setSolanaAddress] = useState<string | null>(() => readSolanaWalletAddress());
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const [logoVideoReady, setLogoVideoReady] = useState(false);
 
   useEffect(() => {
     const sync = () => setSolanaAddress(readSolanaWalletAddress());
@@ -70,17 +68,6 @@ export function Header() {
       window.removeEventListener(WALLET_STATE_UPDATED_EVENT, sync);
       window.removeEventListener('storage', sync);
       window.removeEventListener('focus', sync);
-    };
-  }, []);
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
-    const sync = () => setPrefersReducedMotion(mediaQuery.matches);
-    sync();
-    mediaQuery.addEventListener('change', sync);
-
-    return () => {
-      mediaQuery.removeEventListener('change', sync);
     };
   }, []);
 
@@ -104,7 +91,7 @@ export function Header() {
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-gradient-to-r from-transparent via-[#00e5cc]/50 to-transparent" />
       <div className="h-full max-w-[1440px] mx-auto px-4 flex items-center justify-between">
         <div className="flex items-center gap-6">
-          <Link href="/" className="flex items-center gap-2">
+          <Link href="/" className="flex items-center gap-2.5">
             <div className="relative h-8 w-8 overflow-hidden rounded-lg ring-1 ring-white/15">
               <Image
                 src="/favicon.svg"
@@ -114,24 +101,11 @@ export function Header() {
                 className="object-cover"
                 priority
               />
-              {!prefersReducedMotion && (
-                <video
-                  src="/favicon.mp4"
-                  autoPlay
-                  loop
-                  muted
-                  playsInline
-                  preload="metadata"
-                  onLoadedData={() => setLogoVideoReady(true)}
-                  onError={() => setLogoVideoReady(false)}
-                  className={`absolute inset-0 h-full w-full object-cover transition-opacity duration-200 ${
-                    logoVideoReady ? 'opacity-100' : 'opacity-0'
-                  }`}
-                  aria-label="Animated ArbiMind logo"
-                />
-              )}
             </div>
-            <span className="text-white font-semibold text-lg hidden sm:block">ArbiMind</span>
+            <div className="flex flex-col leading-none">
+              <span className="text-white font-semibold text-base sm:text-lg">ArbiMind</span>
+              <span className="text-[10px] uppercase tracking-[0.18em] text-cyan-300/75 sm:hidden">Arbitrage OS</span>
+            </div>
           </Link>
           <nav className="hidden md:flex items-center gap-1">
             {NAV_ITEMS.map((item) => (
@@ -282,12 +256,16 @@ export function Header() {
                           ctaVariant,
                           pathname,
                         });
-                        openConnectModal?.();
                         setIsWalletModalOpen(false);
+                        window.setTimeout(() => {
+                          openConnectModal?.();
+                        }, 80);
                         return;
                       }
-                      openAccountModal?.();
                       setIsWalletModalOpen(false);
+                      window.setTimeout(() => {
+                        openAccountModal?.();
+                      }, 80);
                     }}
                     className="mb-2 inline-flex h-9 w-full items-center gap-2 rounded-lg border border-[#00e5cc]/60 bg-transparent px-3.5 text-[13px] font-medium text-[#7ff6e7] transition-all duration-150 hover:bg-[#00e5cc]/10"
                   >


### PR DESCRIPTION
## Summary
- remove the fixed mobile bottom bar from the global app shell
- restore the full footer with product, resource, and trust links
- fix mobile branding visibility and remove the broken animated favicon dependency from the header
- sequence the mobile EVM wallet modal so RainbowKit opens after the custom sheet closes

## Why
Nightly smoke is currently treating a missing same-origin asset request as a hard page failure. This change stops the header from requesting the broken favicon video path while also restoring the intended mobile/footer UX.

## Validation
- confirmed no remaining avicon.mp4 references in packages/ui
- could not run pnpm --filter @arbimind/ui lint in this clean worktree because the worktree has no installed 
ode_modules and local eslint is unavailable here
