### PR TITLE
feat(bot): trade size 0.1 ETH, dynamic gas-aware threshold, OPP_NEAR logging, WETH/USDT+ARB pairs

### DIFF
--- a/packages/bot/src/config/index.ts
+++ b/packages/bot/src/config/index.ts
@@ -318,8 +318,8 @@ function createConfig(): BotConfig {
     sanityTxWei,
     sanityTxTo,
 
-    minEdgeBps: parseInt(process.env['MIN_EDGE_BPS'] || '10', 10),
-    swapAmountEth: parseFloat(process.env['SWAP_AMOUNT_ETH'] || '0.001'),
+    minEdgeBps: parseInt(process.env['MIN_EDGE_BPS'] || '8', 10),
+    swapAmountEth: parseFloat(process.env['SWAP_AMOUNT_ETH'] || '0.1'),
   };
 }
 

--- a/packages/bot/src/config/tokens.ts
+++ b/packages/bot/src/config/tokens.ts
@@ -205,6 +205,8 @@ const ARBITRUM_ALLOWLISTED_TOKENS: Record<string, TokenConfig> = {
 const ARBITRUM_TOKEN_PAIRS = [
   { tokenA: 'WETH', tokenB: 'USDC' },
   { tokenA: 'WETH', tokenB: 'USDC.e' },
+  { tokenA: 'WETH', tokenB: 'USDT' },
+  { tokenA: 'WETH', tokenB: 'ARB' },
   { tokenA: 'USDC', tokenB: 'DAI' },
 ];
 

--- a/packages/bot/src/services/ArbitrageBot.ts
+++ b/packages/bot/src/services/ArbitrageBot.ts
@@ -633,7 +633,18 @@ export class ArbitrageBot {
     }
 
     // Find arbitrage opportunities between different DEXes (with spread threshold)
-    const minEdgeBps = this.botConfig.minEdgeBps ?? 10;
+    // Dynamic threshold: floor is gas cost in bps diluted by trade size, plus a safety buffer.
+    // gasGasUnits * gasPrice / (swapAmountEth * ETH_PRICE_USD) * 10000, rounded up to configured floor.
+    const configMinEdgeBps = this.botConfig.minEdgeBps ?? 8;
+    const swapAmountEthNum = this.botConfig.swapAmountEth ?? 0.1;
+    const ARB_GAS_UNITS = 350_000; // conservative estimate for a two-leg arb on Arbitrum
+    const ethPriceUsd = this.cachedEthPriceUsd > 0 ? this.cachedEthPriceUsd : 2200;
+    const gasCostEth = (ARB_GAS_UNITS * this.cachedGasPriceWei) / 1e18;
+    const gasCostBps = swapAmountEthNum > 0
+      ? Math.ceil((gasCostEth / swapAmountEthNum) * 10_000)
+      : configMinEdgeBps;
+    // Floor: at least configMinEdgeBps; add 2 bps safety margin above pure gas cost
+    const minEdgeBps = Math.max(configMinEdgeBps, gasCostBps + 2);
 
     for (let i = 0; i < quotes.length; i++) {
       for (let j = i + 1; j < quotes.length; j++) {
@@ -657,9 +668,26 @@ export class ArbitrageBot {
           v2Price,
           spreadBps: spreadBps.toFixed(2),
           threshold: minEdgeBps,
+          gasCostBps,
+          gasPriceGwei: (this.cachedGasPriceWei / 1e9).toFixed(4),
+          swapAmountEth: swapAmountEthNum,
+          ethPriceUsd: ethPriceUsd.toFixed(2),
         });
 
-        if (spreadBps < minEdgeBps) continue;
+        if (spreadBps < minEdgeBps) {
+          // [OPP_NEAR]: log when spread is within 60% of threshold — useful for tuning
+          if (spreadBps >= minEdgeBps * 0.6) {
+            console.log('[OPP_NEAR]', {
+              pair: `${tokenA}/${tokenB}`,
+              dex1: quote1.dex,
+              dex2: quote2.dex,
+              spreadBps: spreadBps.toFixed(2),
+              threshold: minEdgeBps,
+              gapBps: (minEdgeBps - spreadBps).toFixed(2),
+            });
+          }
+          continue;
+        }
 
         // Reject suspiciously large spreads — likely bad quote or thin liquidity
         if (spreadBps > MAX_SANE_SPREAD_BPS) {

--- a/packages/bot/tests/unit/token-pairs.test.ts
+++ b/packages/bot/tests/unit/token-pairs.test.ts
@@ -61,8 +61,14 @@ describe('getEffectiveTokenPairs', () => {
 
     const { getEffectiveTokenPairs } = await importTokens();
     const pairs = getEffectiveTokenPairs();
+    const pairStrings = pairs.map((p: { tokenA: string; tokenB: string }) => `${p.tokenA}/${p.tokenB}`);
 
-    expect(pairs.length).toBe(3);
+    expect(pairs.length).toBe(5);
+    expect(pairStrings).toContain('WETH/USDC');
+    expect(pairStrings).toContain('WETH/USDC.e');
+    expect(pairStrings).toContain('WETH/USDT');
+    expect(pairStrings).toContain('WETH/ARB');
+    expect(pairStrings).toContain('USDC/DAI');
   });
 
   it('handles reverse pair order in SCAN_PAIRS (USDC.e/WETH)', async () => {
@@ -78,7 +84,7 @@ describe('getEffectiveTokenPairs', () => {
 
   it('warns when SCAN_PAIRS excludes available pairs', async () => {
     setArbitrumProfile();
-    process.env['SCAN_PAIRS'] = 'WETH/USDC,USDC/DAI'; // missing WETH/USDC.e
+    process.env['SCAN_PAIRS'] = 'WETH/USDC,USDC/DAI'; // missing WETH/USDC.e, WETH/USDT, WETH/ARB
 
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -89,7 +95,7 @@ describe('getEffectiveTokenPairs', () => {
     expect(warnSpy).toHaveBeenCalledWith(
       '[SCAN_PAIRS_EXCLUSION]',
       expect.objectContaining({
-        excluded: ['WETH/USDC.e'],
+        excluded: expect.arrayContaining(['WETH/USDC.e', 'WETH/USDT', 'WETH/ARB']),
         reason: 'not in SCAN_PAIRS env var',
       }),
     );


### PR DESCRIPTION
Unit economics tuning — bot was healthy but rejecting 100% of opportunities due to trade-size/gas mismatch. Changes: swapAmountEth 0.001->0.1 ETH; minEdgeBps 10->8 (both env-overridable); dynamic threshold auto-raises during gas spikes (max(configFloor, gasCostBps+2)); [OPP_NEAR] log when spread within 40% of trigger; WETH/USDT + WETH/ARB added to ARBITRUM_TOKEN_PAIRS. TypeScript compiles clean.