### PR TITLE
feat(ui): mobile card layouts for wallet and history tables

### DIFF
--- a/packages/ui/src/app/history/page.tsx
+++ b/packages/ui/src/app/history/page.tsx
@@ -67,7 +67,7 @@ export default function HistoryPage() {
             </div>
             
             {/* Status Filter */}
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <button
                 onClick={() => setFilter('all')}
                 className={`px-4 py-2 rounded-lg text-sm font-medium transition ${
@@ -138,7 +138,70 @@ export default function HistoryPage() {
           </div>
         ) : (
           <div className="glass-card p-4 sm:p-6">
-            <div className="overflow-x-auto">
+            <div className="space-y-2.5 sm:hidden">
+              {filteredTrades.map((trade) => (
+                <div key={trade.id} className="rounded-xl border border-white/10 bg-white/5 p-3">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{trade.tokenPair}</p>
+                      <p className="mt-0.5 text-xs capitalize text-dark-400">{trade.type}</p>
+                    </div>
+                    <span
+                      className={`inline-flex items-center rounded px-2 py-1 text-xs font-medium ${
+                        trade.status === 'success'
+                          ? 'border border-green-500/30 bg-green-500/20 text-green-400'
+                          : 'border border-red-500/30 bg-red-500/20 text-red-400'
+                      }`}
+                    >
+                      {trade.status === 'success' ? (
+                        <>
+                          <TrendingUp className="mr-1 h-3 w-3" />
+                          Success
+                        </>
+                      ) : (
+                        <>
+                          <TrendingDown className="mr-1 h-3 w-3" />
+                          Failed
+                        </>
+                      )}
+                    </span>
+                  </div>
+
+                  <div className="mt-2 grid grid-cols-2 gap-2 text-xs">
+                    <div className="rounded-lg border border-white/10 bg-black/20 px-2.5 py-2">
+                      <p className="text-dark-400">Profit</p>
+                      <p className={`font-semibold ${trade.profit >= 0 ? 'text-green-400' : 'text-red-400'}`}>
+                        {trade.profit >= 0 ? '+' : ''}
+                        {formatETH(trade.profit)}
+                      </p>
+                      <p className="text-[11px] text-dark-500">{formatUSD(trade.profitUsd)}</p>
+                    </div>
+                    <div className="rounded-lg border border-white/10 bg-black/20 px-2.5 py-2">
+                      <p className="text-dark-400">Gas</p>
+                      <p className="font-semibold text-white">{formatETH(trade.gasUsed)}</p>
+                    </div>
+                  </div>
+
+                  <div className="mt-2.5 flex items-center justify-between text-xs text-dark-400">
+                    <span>{trade.timestamp.toLocaleString()}</span>
+                    {trade.txHash ? (
+                      <a
+                        href={`https://etherscan.io/tx/${trade.txHash}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center text-cyan-400 transition hover:text-cyan-300"
+                      >
+                        <ExternalLink className="h-4 w-4" />
+                      </a>
+                    ) : (
+                      <span className="text-dark-500">No tx</span>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="hidden overflow-x-auto sm:block">
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-dark-700">

--- a/packages/ui/src/components/portfolio/ActivityTable.tsx
+++ b/packages/ui/src/components/portfolio/ActivityTable.tsx
@@ -61,54 +61,97 @@ export function ActivityTable({
           <p>No deposits or withdrawals yet</p>
         </div>
       ) : (
-        <div className="overflow-x-auto">
-          <table className="w-full min-w-[420px] xs:min-w-[520px]">
-            <thead>
-              <tr className="border-b border-dark-600">
-                <th className="text-left py-2 text-xs font-medium text-dark-400 uppercase">Tx</th>
-                <th className="text-left py-2 text-xs font-medium text-dark-400 uppercase">Type</th>
-                <th className="text-right py-2 text-xs font-medium text-dark-400 uppercase">Amount</th>
-                <th className="text-right py-2 text-xs font-medium text-dark-400 uppercase">Time</th>
-              </tr>
-            </thead>
-            <tbody>
-              {items.slice(0, 20).map((item) => (
-                <tr
-                  key={`${item.tx}-${item.ts}-${item.type}`}
-                  className="border-b border-dark-700/50 hover:bg-dark-800/30"
-                >
-                  <td className="py-3">
-                    <a
-                      href={txUrl(item.tx)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="inline-flex items-center gap-1 text-cyan-400 hover:underline font-mono text-sm"
-                    >
-                      {formatAddress(item.tx, 8, 8)}
-                      <ExternalLink className="w-3.5 h-3.5" />
-                    </a>
-                  </td>
-                  <td className="py-3">
-                    <span
-                      className={`text-sm font-medium ${
-                        item.type === 'deposit' ? 'text-green-400' : 'text-amber-400'
-                      }`}
-                    >
-                      {item.type === 'deposit' ? 'Deposit' : 'Withdraw'}
-                    </span>
-                  </td>
-                  <td className="py-3 text-right text-sm text-white">
+        <>
+          <div className="space-y-2.5 sm:hidden">
+            {items.slice(0, 20).map((item) => (
+              <div
+                key={`${item.tx}-${item.ts}-${item.type}`}
+                className="rounded-xl border border-white/10 bg-white/5 p-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <a
+                    href={txUrl(item.tx)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center gap-1 font-mono text-sm text-cyan-400 hover:underline"
+                  >
+                    {formatAddress(item.tx, 8, 8)}
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </a>
+                  <span
+                    className={`inline-flex rounded-md border px-2 py-0.5 text-xs font-medium ${
+                      item.type === 'deposit'
+                        ? 'border-green-500/30 bg-green-500/10 text-green-400'
+                        : 'border-amber-500/30 bg-amber-500/10 text-amber-400'
+                    }`}
+                  >
+                    {item.type === 'deposit' ? 'Deposit' : 'Withdraw'}
+                  </span>
+                </div>
+                <div className="mt-2 flex items-center justify-between text-sm">
+                  <span className="text-dark-300">Amount</span>
+                  <span className="font-medium text-white">
                     {item.type === 'deposit' ? '+' : '-'}
                     {item.amount} {item.symbol}
-                  </td>
-                  <td className="py-3 text-right text-xs text-dark-400">
-                    {formatTime(item.ts)}
-                  </td>
+                  </span>
+                </div>
+                <div className="mt-1.5 flex items-center justify-between text-xs text-dark-400">
+                  <span>Time</span>
+                  <span>{formatTime(item.ts)}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="hidden overflow-x-auto sm:block">
+            <table className="w-full min-w-[420px] xs:min-w-[520px]">
+              <thead>
+                <tr className="border-b border-dark-600">
+                  <th className="text-left py-2 text-xs font-medium text-dark-400 uppercase">Tx</th>
+                  <th className="text-left py-2 text-xs font-medium text-dark-400 uppercase">Type</th>
+                  <th className="text-right py-2 text-xs font-medium text-dark-400 uppercase">Amount</th>
+                  <th className="text-right py-2 text-xs font-medium text-dark-400 uppercase">Time</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+              </thead>
+              <tbody>
+                {items.slice(0, 20).map((item) => (
+                  <tr
+                    key={`${item.tx}-${item.ts}-${item.type}`}
+                    className="border-b border-dark-700/50 hover:bg-dark-800/30"
+                  >
+                    <td className="py-3">
+                      <a
+                        href={txUrl(item.tx)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-1 text-cyan-400 hover:underline font-mono text-sm"
+                      >
+                        {formatAddress(item.tx, 8, 8)}
+                        <ExternalLink className="w-3.5 h-3.5" />
+                      </a>
+                    </td>
+                    <td className="py-3">
+                      <span
+                        className={`text-sm font-medium ${
+                          item.type === 'deposit' ? 'text-green-400' : 'text-amber-400'
+                        }`}
+                      >
+                        {item.type === 'deposit' ? 'Deposit' : 'Withdraw'}
+                      </span>
+                    </td>
+                    <td className="py-3 text-right text-sm text-white">
+                      {item.type === 'deposit' ? '+' : '-'}
+                      {item.amount} {item.symbol}
+                    </td>
+                    <td className="py-3 text-right text-xs text-dark-400">
+                      {formatTime(item.ts)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </>
       )}
     </div>
   );


### PR DESCRIPTION
## Problem
Mobile users still had horizontal-scroll-heavy tables in:
- wallet activity list (min width table)
- history trade list

## Changes
- **ActivityTable** (components/portfolio/ActivityTable.tsx)
  - Added mobile-first card list (sm:hidden) for deposits/withdrawals
  - Kept existing table for desktop (hidden sm:block)
  - Preserved tx links, type labels, amount, and timestamp parity
- **History page** (pp/history/page.tsx)
  - Added mobile-first trade cards (sm:hidden) with pair/type, status badge, profit/gas chips, timestamp, tx link
  - Kept existing desktop table (hidden sm:block)
  - Added lex-wrap to status filter button row for narrow viewports

## Validation
- 
pm run build --workspace=@arbimind/ui ✅ (all routes compiled)

## Notes
This continues the same responsive pattern used in OpportunityFeed and keeps desktop behavior unchanged.