### PR TITLE
feat(ui): dashboard analytics polish — strategy comparison images & improved spacing

### DIFF
--- a/packages/ui/src/components/Charts/AnalystCharts.tsx
+++ b/packages/ui/src/components/Charts/AnalystCharts.tsx
@@ -104,12 +104,21 @@ export function AnalystCharts({ strategies, timestamps, totalTrades }: AnalystCh
             </PieChart>
           </SafeResponsiveContainer>
         </div>
-        <div className="mt-3 overflow-hidden rounded-lg border border-dark-700 bg-dark-900/40">
-          <img
-            src="/ArbiMind_4.jpg"
-            alt="ArbiMind live-ready strategy overview"
-            className="h-auto w-full object-cover"
-          />
+        <div className="mt-6 grid grid-cols-2 gap-3">
+          <div className="overflow-hidden rounded-lg border border-dark-700 bg-dark-900/40">
+            <img
+              src="/ArbiMind_4.jpg"
+              alt="ArbiMind live-ready strategy overview"
+              className="h-56 w-full object-cover"
+            />
+          </div>
+          <div className="overflow-hidden rounded-lg border border-dark-700 bg-dark-900/40">
+            <img
+              src="/6Y4Yn.jpg"
+              alt="ArbiMind mobile optimized interface"
+              className="h-56 w-full object-cover"
+            />
+          </div>
         </div>
       </div>
       <div>


### PR DESCRIPTION
## Summary

Continued UI polish for the ArbiMind dashboard after PR #271 merged. Focused on improving the Strategy Profit section visibility.

## Changes

- **Larger strategy mockup image**: Increased height to 224px (\h-56\) with \object-cover\ for consistent aspect ratio
- **Increased vertical spacing**: Changed \mt-3\ to \mt-6\ between donut chart and images
- **Side-by-side comparison**: Added two images (50/50 split) showing desktop strategy overview + mobile interface mockup
  - Left: ArbiMind_4.jpg (strategy overview)
  - Right: 6Y4Yn.jpg (mobile interface mockup)
  - Both \h-56\, responsive grid with \gap-3\

## Build
✓ Compiled successfully — all 27 pages green